### PR TITLE
[New module] Freesurfer registration/convert

### DIFF
--- a/modules/nf-neuro/registration/convert/environment.yml
+++ b/modules/nf-neuro/registration/convert/environment.yml
@@ -1,7 +1,3 @@
----
-name: "registration_convert"
-channels:
-  - Docker
-  - Apptainer
-dependencies:
-  - "Freesurfer"
+channels: []
+dependencies: []
+name: registration_convert

--- a/modules/nf-neuro/registration/convert/environment.yml
+++ b/modules/nf-neuro/registration/convert/environment.yml
@@ -1,0 +1,7 @@
+---
+name: "registration_convert"
+channels:
+  - Docker
+  - Apptainer
+dependencies:
+  - "Freesurfer"

--- a/modules/nf-neuro/registration/convert/main.nf
+++ b/modules/nf-neuro/registration/convert/main.nf
@@ -7,7 +7,7 @@ process REGISTRATION_CONVERT {
     containerOptions "--env FSLOUTPUTTYPE='NIFTI_GZ'"
 
     input:
-    tuple val(meta), path(affine), path(deform), path(source), path(target) /* optional, value = [] */, path(fs_license) /* optional, value = [] */
+    tuple val(meta), path(affine), path(deform), path(source), path(target), path(fs_license)
 
     output:
     tuple val(meta), path("*.{txt,lta,mat,dat}"), emit: affine_transform
@@ -23,10 +23,10 @@ process REGISTRATION_CONVERT {
 
     //For arguments definition, lta_convert -h
     def invert = task.ext.invert ? "--invert" : ""
-    def source_geometry_init = "$source" ? "--src " + "$source" : ""
-    def target_geometry_init = "$target" ? "--trg " + "$target" : ""
-    def in_format_init = task.ext.in_format_init ? "--in" + task.ext.in_format_init + " " + "$affine" : "--inlta " + "$affine"
-    def out_format_init = task.ext.out_format_init ? "--out" + task.ext.out_format_init : "--outitk"
+    def source_geometry_affine = "$source" ? "--src " + "$source" : ""
+    def target_geometry_affine = "$target" ? "--trg " + "$target" : ""
+    def in_format_affine = task.ext.in_format_affine ? "--in" + task.ext.in_format_affine + " " + "$affine" : "--inlta " + "$affine"
+    def out_format_affine = task.ext.out_format_affine ? "--out" + task.ext.out_format_affine : "--outitk"
 
     //For arguments definition, mri_warp_convert -h
     def source_geometry_deform = "$source" ? "--insrcgeom " + "$source" : ""
@@ -49,7 +49,7 @@ process REGISTRATION_CONVERT {
                                     ["--outitk"]="txt" \
                                     ["--outvox"]="txt" )
 
-    ext_affine=\${affine_dictionnary[${out_format_init}]}
+    ext_affine=\${affine_dictionnary[${out_format_affine}]}
 
     declare -A deform_dictionnary=( ["--outm3z"]="m3z" \
                                     ["--outfsl"]="nii.gz" \
@@ -60,7 +60,7 @@ process REGISTRATION_CONVERT {
 
     ext_deform=\${deform_dictionnary[${out_format_deform}]}
 
-    lta_convert ${invert} ${source_geometry_init} ${target_geometry_init} ${in_format_init} ${out_format_init} ${prefix}__init_warp.\${ext_affine}
+    lta_convert ${invert} ${source_geometry_affine} ${target_geometry_affine} ${in_format_affine} ${out_format_affine} ${prefix}__affine_warp.\${ext_affine}
     mri_warp_convert ${source_geometry_deform} ${downsample} ${in_format_deform} ${out_format_deform}  ${prefix}__deform_warp.\${ext_deform}
 
     rm \$FREESURFER_HOME/license.txt
@@ -79,7 +79,7 @@ process REGISTRATION_CONVERT {
     lta_convert -h
     mri_warp_convert -h
 
-    touch ${prefix}__init_transform.txt
+    touch ${prefix}__affine_transform.txt
     touch ${prefix}__deform_transform.nii.gz
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-neuro/registration/convert/main.nf
+++ b/modules/nf-neuro/registration/convert/main.nf
@@ -3,7 +3,6 @@ process REGISTRATION_CONVERT {
     label 'process_single'
 
     container "freesurfer/freesurfer:7.4.1"
-    containerOptions "--entrypoint ''"
     containerOptions "--env FSLOUTPUTTYPE='NIFTI_GZ'"
 
     input:

--- a/modules/nf-neuro/registration/convert/main.nf
+++ b/modules/nf-neuro/registration/convert/main.nf
@@ -10,7 +10,7 @@ process REGISTRATION_CONVERT {
     tuple val(meta), path(affine), path(deform), path(source), path(target) /* optional, value = [] */, path(fs_license) /* optional, value = [] */
 
     output:
-    tuple val(meta), path("*.{txt,lta,mat,dat}"), emit: init_transform
+    tuple val(meta), path("*.{txt,lta,mat,dat}"), emit: affine_transform
     tuple val(meta), path("*.{nii,nii.gz,mgz,m3z}"), emit: deform_transform
     path "versions.yml"           , emit: versions
 

--- a/modules/nf-neuro/registration/convert/main.nf
+++ b/modules/nf-neuro/registration/convert/main.nf
@@ -1,0 +1,90 @@
+process REGISTRATION_CONVERT {
+    tag "$meta.id"
+    label 'process_single'
+
+    container "freesurfer/freesurfer:7.4.1"
+    containerOptions "--entrypoint ''"
+    containerOptions "--env FSLOUTPUTTYPE='NIFTI_GZ'"
+
+    input:
+    tuple val(meta), path(affine), path(deform), path(source), path(target) /* optional, value = [] */, path(fs_license) /* optional, value = [] */
+
+    output:
+    tuple val(meta), path("*.{txt,lta,mat,dat}"), emit: init_transform
+    tuple val(meta), path("*.{nii,nii.gz,mgz,m3z}"), emit: deform_transform
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    //For arguments definition, lta_convert -h
+    def invert = task.ext.invert ? "--invert" : ""
+    def source_geometry_init = "$source" ? "--src " + "$source" : ""
+    def target_geometry_init = "$target" ? "--trg " + "$target" : ""
+    def in_format_init = task.ext.in_format_init ? "--in" + task.ext.in_format_init + " " + "$affine" : "--inlta " + "$affine"
+    def out_format_init = task.ext.out_format_init ? "--out" + task.ext.out_format_init : "--outitk"
+
+    //For arguments definition, mri_warp_convert -h
+    def source_geometry_deform = "$source" ? "--insrcgeom " + "$source" : ""
+    def in_format_deform = task.ext.in_format_deform ? "--in" + task.ext.in_format_deform + " " + "$deform" : "--inras " + "$deform"
+    def out_format_deform = task.ext.out_format_deform ? "--out" + task.ext.out_format_deform : "--outitk"
+    def downsample = task.ext.downsample ? "--downsample" : ""
+
+    """
+    export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=$task.cpus
+    export OMP_NUM_THREADS=1
+    export OPENBLAS_NUM_THREADS=1
+
+    cp $fs_license \$FREESURFER_HOME/license.txt
+
+    declare -A affine_dictionnary=( ["--outlta"]="lta" \
+                                    ["--outfsl"]="mat" \
+                                    ["--outmni"]="xfm" \
+                                    ["--outreg"]="dat" \
+                                    ["--outniftyreg"]="txt" \
+                                    ["--outitk"]="txt" \
+                                    ["--outvox"]="txt" )
+
+    ext_affine=\${affine_dictionnary[${out_format_init}]}
+
+    declare -A deform_dictionnary=( ["--outm3z"]="m3z" \
+                                    ["--outfsl"]="nii.gz" \
+                                    ["--outlps"]="nii.gz" \
+                                    ["--outitk"]="nii.gz" \
+                                    ["--outras"]="nii.gz" \
+                                    ["--outvox"]="mgz" )
+
+    ext_deform=\${deform_dictionnary[${out_format_deform}]}
+
+    lta_convert ${invert} ${source_geometry_init} ${target_geometry_init} ${in_format_init} ${out_format_init} ${prefix}__init_warp.\${ext_affine}
+    mri_warp_convert ${source_geometry_deform} ${downsample} ${in_format_deform} ${out_format_deform}  ${prefix}__deform_warp.\${ext_deform}
+
+    rm \$FREESURFER_HOME/license.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        Freesurfer: 7.4.1
+    END_VERSIONS
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    lta_convert -h
+    mri_warp_convert -h
+
+    touch ${prefix}__init_transform.txt
+    touch ${prefix}__deform_transform.nii.gz
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        Freesurfer: 7.4.1
+    END_VERSIONS
+    """
+}

--- a/modules/nf-neuro/registration/convert/meta.yml
+++ b/modules/nf-neuro/registration/convert/meta.yml
@@ -1,10 +1,11 @@
 ---
 name: "registration_convert"
-description: Freesurfer transform conversion tool. Default usage is aim at receiving freesurfer format and converting to ANTs (ITK). See lta_convert --help and mri_warp_convert --help for alternatives.
+description: Freesurfer transform conversion tool. Default usage is aim at receiving freesurfer format and converting to ANTs (ITK). See lta_convert --help and mri_warp_convert --help for options.
 keywords:
   - Registration
   - Brain imaging
   - MRI
+  - Conversion
 tools:
   - "Freesurfer":
       description: "Freesurfer lta_convert (affine conversion) and mri_warp_convert (deform) tools for transform conversion"
@@ -50,9 +51,9 @@ output:
         Groovy Map containing sample information
         e.g. `[ id:'test', single_end:false ]`
 
-  - init_transform:
+  - affine_transform:
       type: file
-      description: Init transform. Default usage outputs ANTs (ITK) format .txt
+      description: Affine transform. Default usage outputs ANTs (ITK) format .txt
       pattern: "*.{txt,lta,mat,dat}"
 
   - deform_transform:

--- a/modules/nf-neuro/registration/convert/meta.yml
+++ b/modules/nf-neuro/registration/convert/meta.yml
@@ -1,0 +1,69 @@
+---
+name: "registration_convert"
+description: Freesurfer transform conversion tool. Default usage is aim at receiving freesurfer format and converting to ANTs (ITK). See lta_convert --help and mri_warp_convert --help for alternatives.
+keywords:
+  - Registration
+  - Brain imaging
+  - MRI
+tools:
+  - "Freesurfer":
+      description: "Freesurfer lta_convert (affine conversion) and mri_warp_convert (deform) tools for transform conversion"
+      homepage: "https://surfer.nmr.mgh.harvard.edu/"
+      documentation: "https://surfer.nmr.mgh.harvard.edu/fswiki/FreeSurferWiki"
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'test', single_end:false ]`
+
+  - affine:
+      type: file
+      description: Affine transform to convert. Default usage expects Freesurfer .lta format from mri_synthmorph
+      pattern: "*.{lta,txt,xfm,dat}"
+
+  - deform:
+      type: file
+      description: Deform transform to convert. Default usage expects Freesurfer .mgz format from mri_synthmorph
+      pattern: "*.{nii,nii.gz,mgz,m3z}"
+
+  - source:
+      type: file
+      description: Moving Nifti volume used for registration. Defines source image geometry
+      pattern: "*.{nii,nii.gz}"
+
+  - target:
+      type: file
+      description: Fixed Nifti volume used for registration. Defines target image geometry. (optional)
+      pattern: "*.{nii,nii.gz}"
+
+  - fs_license:
+      type: file
+      description: The path to your FreeSurfer license. To get one, go to https://surfer.nmr.mgh.harvard.edu/registration.html. Optional. If you have already set your license as prescribed by Freesurfer (copied to a .license file in your $FREESURFER_HOME), this is not required.
+      pattern: "*.txt"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'test', single_end:false ]`
+
+  - init_transform:
+      type: file
+      description: Init transform. Default usage outputs ANTs (ITK) format .txt
+      pattern: "*.{txt,lta,mat,dat}"
+
+  - deform_transform:
+      type: file
+      description: Deform transform. Default usage outputs ANTs (ITK) format .nii.gz
+      pattern: "*.{nii,nii.gz,mgz,m3z}"
+
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+
+authors:
+  - "@anroy1"

--- a/modules/nf-neuro/registration/convert/tests/main.nf.test
+++ b/modules/nf-neuro/registration/convert/tests/main.nf.test
@@ -15,7 +15,7 @@ nextflow_process {
 
     setup {
         run("LOAD_TEST_DATA", alias: "LOAD_DATA") {
-            script "../../../../../subworkflows/nf-scil/load_test_data/main.nf"
+            script "../../../../../subworkflows/nf-neuro/load_test_data/main.nf"
             process {
                 """
                 input[0] = Channel.from( [ "freesurfer.zip" , "freesurfer_reslice.zip" , "freesurfer_transforms.zip"] )

--- a/modules/nf-neuro/registration/convert/tests/main.nf.test
+++ b/modules/nf-neuro/registration/convert/tests/main.nf.test
@@ -1,0 +1,267 @@
+nextflow_process {
+
+    name "Test Process REGISTRATION_CONVERT"
+    script "../main.nf"
+    process "REGISTRATION_CONVERT"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "registration"
+    tag "registration/convert"
+
+    tag "subworkflows"
+    tag "subworkflows/load_test_data"
+
+
+    setup {
+        run("LOAD_TEST_DATA", alias: "LOAD_DATA") {
+            script "../../../../../subworkflows/nf-scil/load_test_data/main.nf"
+            process {
+                """
+                input[0] = Channel.from( [ "freesurfer.zip" , "freesurfer_reslice.zip" , "freesurfer_transforms.zip"] )
+                input[1] = "test.load-test-data"
+                """
+            }
+        }
+    }
+
+    test("registration - convert - default") {
+
+        config "./nextflow_default.config"
+
+        when {
+            process {
+                """
+                ch_split_test_data = LOAD_DATA.out.test_data_directory
+                    .branch{
+                        freesurfer: it.simpleName == "freesurfer"
+                        reslice: it.simpleName == "freesurfer_reslice"
+                        transforms: it.simpleName == "freesurfer_transforms"
+                    }
+                ch_transforms = ch_split_test_data.transforms.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/fs_affine.lta"),
+                        file("\${test_data_directory}/fs_deform.nii.gz"),
+                    ]
+                }
+                ch_reslice = ch_split_test_data.reslice.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/t1_reslice.nii.gz"),
+                        []
+                    ]
+                }
+                ch_freesurfer = ch_split_test_data.freesurfer.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/license.txt")
+                    ]
+                }
+                input[0] = ch_transforms
+                    .join(ch_reslice)
+                    .join(ch_freesurfer)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("registration - convert - fsants") {
+
+        config "./nextflow_fsants.config"
+
+        when {
+            process {
+                """
+                ch_split_test_data = LOAD_DATA.out.test_data_directory
+                    .branch{
+                        freesurfer: it.simpleName == "freesurfer"
+                        reslice: it.simpleName == "freesurfer_reslice"
+                        transforms: it.simpleName == "freesurfer_transforms"
+                    }
+                ch_transforms = ch_split_test_data.transforms.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/fs_affine.lta"),
+                        file("\${test_data_directory}/fs_deform.nii.gz")
+                    ]
+                }
+                ch_reslice = ch_split_test_data.reslice.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/t1_reslice.nii.gz"),
+                        file("\${test_data_directory}/fa_reslice.nii.gz")
+                    ]
+                }
+                ch_freesurfer = ch_split_test_data.freesurfer.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/license.txt")
+                    ]
+                }
+                input[0] = ch_transforms
+                    .join(ch_reslice)
+                    .join(ch_freesurfer)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("registration - convert - fslfs") {
+
+        config "./nextflow_fslfs.config"
+
+        when {
+            process {
+                """
+                ch_split_test_data = LOAD_DATA.out.test_data_directory
+                    .branch{
+                        freesurfer: it.simpleName == "freesurfer"
+                        reslice: it.simpleName == "freesurfer_reslice"
+                        transforms: it.simpleName == "freesurfer_transforms"
+                    }
+                ch_transforms = ch_split_test_data.transforms.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/fsl_affine.mat"),
+                        file("\${test_data_directory}/fsl_deform.nii.gz")
+                    ]
+                }
+                ch_reslice = ch_split_test_data.reslice.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/t1_reslice.nii.gz"),
+                        file("\${test_data_directory}/fa_reslice.nii.gz")
+                    ]
+                }
+                ch_freesurfer = ch_split_test_data.freesurfer.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/license.txt")
+                    ]
+                }
+                input[0] = ch_transforms
+                    .join(ch_reslice)
+                    .join(ch_freesurfer)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("registration - convert - fslants") {
+
+        config "./nextflow_fslants.config"
+
+        when {
+            process {
+                """
+                ch_split_test_data = LOAD_DATA.out.test_data_directory
+                    .branch{
+                        freesurfer: it.simpleName == "freesurfer"
+                        reslice: it.simpleName == "freesurfer_reslice"
+                        transforms: it.simpleName == "freesurfer_transforms"
+                    }
+                ch_transforms = ch_split_test_data.transforms.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/fsl_affine.mat"),
+                        file("\${test_data_directory}/fsl_deform.nii.gz")
+                    ]
+                }
+                ch_reslice = ch_split_test_data.reslice.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/t1_reslice.nii.gz"),
+                        file("\${test_data_directory}/fa_reslice.nii.gz")
+                    ]
+                }
+                ch_freesurfer = ch_split_test_data.freesurfer.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/license.txt")
+                    ]
+                }
+                input[0] = ch_transforms
+                    .join(ch_reslice)
+                    .join(ch_freesurfer)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("registration - convert - antsfs") {
+
+        config "./nextflow_antsfs.config"
+
+        when {
+            process {
+                """
+                ch_split_test_data = LOAD_DATA.out.test_data_directory
+                    .branch{
+                        freesurfer: it.simpleName == "freesurfer"
+                        reslice: it.simpleName == "freesurfer_reslice"
+                        transforms: it.simpleName == "freesurfer_transforms"
+                    }
+                ch_transforms = ch_split_test_data.transforms.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/ants_affine.txt"),
+                        file("\${test_data_directory}/ants_deform.nii.gz")
+                    ]
+                }
+                ch_reslice = ch_split_test_data.reslice.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/t1_reslice.nii.gz"),
+                        file("\${test_data_directory}/fa_reslice.nii.gz")
+                    ]
+                }
+                ch_freesurfer = ch_split_test_data.freesurfer.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/license.txt")
+                    ]
+                }
+                input[0] = ch_transforms
+                    .join(ch_reslice)
+                    .join(ch_freesurfer)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-neuro/registration/convert/tests/main.nf.test
+++ b/modules/nf-neuro/registration/convert/tests/main.nf.test
@@ -164,7 +164,11 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    file(process.out.affine_transform.get(0).get(1)).name,
+                    process.out.deform_transform,
+                    process.out.versions
+                ).match() }
             )
         }
     }
@@ -260,7 +264,11 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    file(process.out.affine_transform.get(0).get(1)).name,
+                    process.out.deform_transform,
+                    process.out.versions
+                ).match() }
             )
         }
     }

--- a/modules/nf-neuro/registration/convert/tests/main.nf.test.snap
+++ b/modules/nf-neuro/registration/convert/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "test"
                         },
-                        "test__init_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
+                        "test__affine_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
                     ]
                 ],
                 "1": [
@@ -26,7 +26,7 @@
                         {
                             "id": "test"
                         },
-                        "test__init_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
+                        "test__affine_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
                     ]
                 ],
                 "deform_transform": [
@@ -46,7 +46,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-09-24T19:51:31.308519"
+        "timestamp": "2024-09-24T20:50:14.250271"
     },
     "registration - convert - default": {
         "content": [
@@ -56,7 +56,7 @@
                         {
                             "id": "test"
                         },
-                        "test__init_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
+                        "test__affine_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
                     ]
                 ],
                 "1": [
@@ -75,7 +75,7 @@
                         {
                             "id": "test"
                         },
-                        "test__init_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
+                        "test__affine_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
                     ]
                 ],
                 "deform_transform": [
@@ -95,56 +95,28 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-09-24T19:51:26.803266"
+        "timestamp": "2024-09-24T20:50:09.870665"
     },
     "registration - convert - antsfs": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test__init_warp.lta:md5,d3afe0fa6944ead0c7289bcbcda104e2"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test__deform_warp.nii.gz:md5,599fbe3a6b85d61c0c67cea8be4972b7"
-                    ]
-                ],
-                "2": [
-                    "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
-                ],
-                "affine_transform": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test__init_warp.lta:md5,d3afe0fa6944ead0c7289bcbcda104e2"
-                    ]
-                ],
-                "deform_transform": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test__deform_warp.nii.gz:md5,599fbe3a6b85d61c0c67cea8be4972b7"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
+            "test__affine_warp.lta",
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test__deform_warp.nii.gz:md5,599fbe3a6b85d61c0c67cea8be4972b7"
                 ]
-            }
+            ],
+            [
+                "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
+            ]
         ],
         "meta": {
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-09-24T19:52:03.847929"
+        "timestamp": "2024-09-24T20:50:44.315777"
     },
     "registration - convert - fslants": {
         "content": [
@@ -154,7 +126,7 @@
                         {
                             "id": "test"
                         },
-                        "test__init_warp.txt:md5,074e8ac5777a91ba0808cd58c5a0cc44"
+                        "test__affine_warp.txt:md5,074e8ac5777a91ba0808cd58c5a0cc44"
                     ]
                 ],
                 "1": [
@@ -173,7 +145,7 @@
                         {
                             "id": "test"
                         },
-                        "test__init_warp.txt:md5,074e8ac5777a91ba0808cd58c5a0cc44"
+                        "test__affine_warp.txt:md5,074e8ac5777a91ba0808cd58c5a0cc44"
                     ]
                 ],
                 "deform_transform": [
@@ -193,55 +165,27 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-09-24T19:51:59.053418"
+        "timestamp": "2024-09-24T20:50:39.752948"
     },
     "registration - convert - fslfs": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test__init_warp.lta:md5,98fae3bce7cfc2ba2383c9d120d38dcd"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test__deform_warp.nii.gz:md5,df432a27c586e57cad93af7509941cd4"
-                    ]
-                ],
-                "2": [
-                    "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
-                ],
-                "affine_transform": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test__init_warp.lta:md5,98fae3bce7cfc2ba2383c9d120d38dcd"
-                    ]
-                ],
-                "deform_transform": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test__deform_warp.nii.gz:md5,df432a27c586e57cad93af7509941cd4"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
+            "test__affine_warp.lta",
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test__deform_warp.nii.gz:md5,df432a27c586e57cad93af7509941cd4"
                 ]
-            }
+            ],
+            [
+                "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
+            ]
         ],
         "meta": {
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-09-24T19:51:45.41656"
+        "timestamp": "2024-09-24T20:50:26.951153"
     }
 }

--- a/modules/nf-neuro/registration/convert/tests/main.nf.test.snap
+++ b/modules/nf-neuro/registration/convert/tests/main.nf.test.snap
@@ -21,20 +21,20 @@
                 "2": [
                     "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
                 ],
+                "affine_transform": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__init_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
+                    ]
+                ],
                 "deform_transform": [
                     [
                         {
                             "id": "test"
                         },
                         "test__deform_warp.nii.gz:md5,69052e6226da946bad1f9466285cbb89"
-                    ]
-                ],
-                "init_transform": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test__init_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
                     ]
                 ],
                 "versions": [
@@ -46,7 +46,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-09-24T13:35:37.562833"
+        "timestamp": "2024-09-24T19:51:31.308519"
     },
     "registration - convert - default": {
         "content": [
@@ -70,20 +70,20 @@
                 "2": [
                     "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
                 ],
+                "affine_transform": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__init_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
+                    ]
+                ],
                 "deform_transform": [
                     [
                         {
                             "id": "test"
                         },
                         "test__deform_warp.nii.gz:md5,69052e6226da946bad1f9466285cbb89"
-                    ]
-                ],
-                "init_transform": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test__init_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
                     ]
                 ],
                 "versions": [
@@ -95,7 +95,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-09-24T13:35:31.823233"
+        "timestamp": "2024-09-24T19:51:26.803266"
     },
     "registration - convert - antsfs": {
         "content": [
@@ -105,7 +105,7 @@
                         {
                             "id": "test"
                         },
-                        "test__init_warp.lta:md5,12c3608398da5039c99173160c1dc1a0"
+                        "test__init_warp.lta:md5,d3afe0fa6944ead0c7289bcbcda104e2"
                     ]
                 ],
                 "1": [
@@ -119,20 +119,20 @@
                 "2": [
                     "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
                 ],
+                "affine_transform": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__init_warp.lta:md5,d3afe0fa6944ead0c7289bcbcda104e2"
+                    ]
+                ],
                 "deform_transform": [
                     [
                         {
                             "id": "test"
                         },
                         "test__deform_warp.nii.gz:md5,599fbe3a6b85d61c0c67cea8be4972b7"
-                    ]
-                ],
-                "init_transform": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test__init_warp.lta:md5,12c3608398da5039c99173160c1dc1a0"
                     ]
                 ],
                 "versions": [
@@ -144,7 +144,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-09-24T13:36:08.620317"
+        "timestamp": "2024-09-24T19:52:03.847929"
     },
     "registration - convert - fslants": {
         "content": [
@@ -168,20 +168,20 @@
                 "2": [
                     "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
                 ],
+                "affine_transform": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__init_warp.txt:md5,074e8ac5777a91ba0808cd58c5a0cc44"
+                    ]
+                ],
                 "deform_transform": [
                     [
                         {
                             "id": "test"
                         },
                         "test__deform_warp.nii.gz:md5,94feb8f0e648256eaa5ae0a47e5702c6"
-                    ]
-                ],
-                "init_transform": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test__init_warp.txt:md5,074e8ac5777a91ba0808cd58c5a0cc44"
                     ]
                 ],
                 "versions": [
@@ -193,7 +193,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-09-24T13:36:03.894093"
+        "timestamp": "2024-09-24T19:51:59.053418"
     },
     "registration - convert - fslfs": {
         "content": [
@@ -203,7 +203,7 @@
                         {
                             "id": "test"
                         },
-                        "test__init_warp.lta:md5,de6b45f72c3fcec98c3cd1ab97967154"
+                        "test__init_warp.lta:md5,98fae3bce7cfc2ba2383c9d120d38dcd"
                     ]
                 ],
                 "1": [
@@ -217,20 +217,20 @@
                 "2": [
                     "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
                 ],
+                "affine_transform": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__init_warp.lta:md5,98fae3bce7cfc2ba2383c9d120d38dcd"
+                    ]
+                ],
                 "deform_transform": [
                     [
                         {
                             "id": "test"
                         },
                         "test__deform_warp.nii.gz:md5,df432a27c586e57cad93af7509941cd4"
-                    ]
-                ],
-                "init_transform": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test__init_warp.lta:md5,de6b45f72c3fcec98c3cd1ab97967154"
                     ]
                 ],
                 "versions": [
@@ -242,6 +242,6 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-09-24T13:35:50.821192"
+        "timestamp": "2024-09-24T19:51:45.41656"
     }
 }

--- a/modules/nf-neuro/registration/convert/tests/main.nf.test.snap
+++ b/modules/nf-neuro/registration/convert/tests/main.nf.test.snap
@@ -1,0 +1,247 @@
+{
+    "registration - convert - fsants": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__init_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__deform_warp.nii.gz:md5,69052e6226da946bad1f9466285cbb89"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
+                ],
+                "deform_transform": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__deform_warp.nii.gz:md5,69052e6226da946bad1f9466285cbb89"
+                    ]
+                ],
+                "init_transform": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__init_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-09-24T13:35:37.562833"
+    },
+    "registration - convert - default": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__init_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__deform_warp.nii.gz:md5,69052e6226da946bad1f9466285cbb89"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
+                ],
+                "deform_transform": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__deform_warp.nii.gz:md5,69052e6226da946bad1f9466285cbb89"
+                    ]
+                ],
+                "init_transform": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__init_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-09-24T13:35:31.823233"
+    },
+    "registration - convert - antsfs": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__init_warp.lta:md5,12c3608398da5039c99173160c1dc1a0"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__deform_warp.nii.gz:md5,599fbe3a6b85d61c0c67cea8be4972b7"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
+                ],
+                "deform_transform": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__deform_warp.nii.gz:md5,599fbe3a6b85d61c0c67cea8be4972b7"
+                    ]
+                ],
+                "init_transform": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__init_warp.lta:md5,12c3608398da5039c99173160c1dc1a0"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-09-24T13:36:08.620317"
+    },
+    "registration - convert - fslants": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__init_warp.txt:md5,074e8ac5777a91ba0808cd58c5a0cc44"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__deform_warp.nii.gz:md5,94feb8f0e648256eaa5ae0a47e5702c6"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
+                ],
+                "deform_transform": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__deform_warp.nii.gz:md5,94feb8f0e648256eaa5ae0a47e5702c6"
+                    ]
+                ],
+                "init_transform": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__init_warp.txt:md5,074e8ac5777a91ba0808cd58c5a0cc44"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-09-24T13:36:03.894093"
+    },
+    "registration - convert - fslfs": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__init_warp.lta:md5,de6b45f72c3fcec98c3cd1ab97967154"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__deform_warp.nii.gz:md5,df432a27c586e57cad93af7509941cd4"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
+                ],
+                "deform_transform": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__deform_warp.nii.gz:md5,df432a27c586e57cad93af7509941cd4"
+                    ]
+                ],
+                "init_transform": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__init_warp.lta:md5,de6b45f72c3fcec98c3cd1ab97967154"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-09-24T13:35:50.821192"
+    }
+}

--- a/modules/nf-neuro/registration/convert/tests/nextflow_antsfs.config
+++ b/modules/nf-neuro/registration/convert/tests/nextflow_antsfs.config
@@ -1,0 +1,9 @@
+process {
+    withName: "REGISTRATION_CONVERT" {
+        publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+        ext.in_format_init = "itk"
+        ext.out_format_init = "lta"
+        ext.in_format_deform = "itk"
+        ext.out_format_deform = "ras"
+    }
+}

--- a/modules/nf-neuro/registration/convert/tests/nextflow_antsfs.config
+++ b/modules/nf-neuro/registration/convert/tests/nextflow_antsfs.config
@@ -1,8 +1,8 @@
 process {
     withName: "REGISTRATION_CONVERT" {
         publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
-        ext.in_format_init = "itk"
-        ext.out_format_init = "lta"
+        ext.in_format_affine = "itk"
+        ext.out_format_affine = "lta"
         ext.in_format_deform = "itk"
         ext.out_format_deform = "ras"
     }

--- a/modules/nf-neuro/registration/convert/tests/nextflow_default.config
+++ b/modules/nf-neuro/registration/convert/tests/nextflow_default.config
@@ -1,0 +1,5 @@
+process {
+    withName: "REGISTRATION_CONVERT" {
+        publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+    }
+}

--- a/modules/nf-neuro/registration/convert/tests/nextflow_fsants.config
+++ b/modules/nf-neuro/registration/convert/tests/nextflow_fsants.config
@@ -1,0 +1,9 @@
+process {
+    withName: "REGISTRATION_CONVERT" {
+        publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+        ext.in_format_init = "lta"
+        ext.out_format_init = "itk"
+        ext.in_format_deform = "ras"
+        ext.out_format_deform = "itk"
+    }
+}

--- a/modules/nf-neuro/registration/convert/tests/nextflow_fsants.config
+++ b/modules/nf-neuro/registration/convert/tests/nextflow_fsants.config
@@ -1,8 +1,8 @@
 process {
     withName: "REGISTRATION_CONVERT" {
         publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
-        ext.in_format_init = "lta"
-        ext.out_format_init = "itk"
+        ext.in_format_affine = "lta"
+        ext.out_format_affine = "itk"
         ext.in_format_deform = "ras"
         ext.out_format_deform = "itk"
     }

--- a/modules/nf-neuro/registration/convert/tests/nextflow_fslants.config
+++ b/modules/nf-neuro/registration/convert/tests/nextflow_fslants.config
@@ -1,0 +1,9 @@
+process {
+    withName: "REGISTRATION_CONVERT" {
+        publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+        ext.in_format_init = "fsl"
+        ext.out_format_init = "itk"
+        ext.in_format_deform = "fsl"
+        ext.out_format_deform = "itk"
+    }
+}

--- a/modules/nf-neuro/registration/convert/tests/nextflow_fslants.config
+++ b/modules/nf-neuro/registration/convert/tests/nextflow_fslants.config
@@ -1,8 +1,8 @@
 process {
     withName: "REGISTRATION_CONVERT" {
         publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
-        ext.in_format_init = "fsl"
-        ext.out_format_init = "itk"
+        ext.in_format_affine = "fsl"
+        ext.out_format_affine = "itk"
         ext.in_format_deform = "fsl"
         ext.out_format_deform = "itk"
     }

--- a/modules/nf-neuro/registration/convert/tests/nextflow_fslfs.config
+++ b/modules/nf-neuro/registration/convert/tests/nextflow_fslfs.config
@@ -1,8 +1,8 @@
 process {
     withName: "REGISTRATION_CONVERT" {
         publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
-        ext.in_format_init = "fsl"
-        ext.out_format_init = "lta"
+        ext.in_format_affine = "fsl"
+        ext.out_format_affine = "lta"
         ext.in_format_deform = "fsl"
         ext.out_format_deform = "ras"
     }

--- a/modules/nf-neuro/registration/convert/tests/nextflow_fslfs.config
+++ b/modules/nf-neuro/registration/convert/tests/nextflow_fslfs.config
@@ -1,0 +1,9 @@
+process {
+    withName: "REGISTRATION_CONVERT" {
+        publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+        ext.in_format_init = "fsl"
+        ext.out_format_init = "lta"
+        ext.in_format_deform = "fsl"
+        ext.out_format_deform = "ras"
+    }
+}

--- a/modules/nf-neuro/registration/convert/tests/tags.yml
+++ b/modules/nf-neuro/registration/convert/tests/tags.yml
@@ -1,0 +1,2 @@
+registration/convert:
+  - "modules/nf-neuro/registration/convert/**"


### PR DESCRIPTION
## Describe your changes

Add the synthbet option to preproc_t1Warp conversion module - designed initially to convert freesurfer registration warp (affine and deform) to ants-itk. Then decided to generalize the module for all cases possible. Receives one affine matrix, one deform warp, source and target images for orientation (and freesurfer licence) and outputs converted affine and deform.

## List test packages used by your module

- `freeurfer.zip`
- `freesurfer_relice.zip`
- `freesurfer_transforms.zip`

## Checklist before requesting a review

- Create the tool:
  - [x] Edit `./modules/nf-scil/<category>/<tool>/main.nf`
  - [x] Edit `./modules/nf-scil/<category>/<tool>/meta.yml`
- Generate the tests:
  - [x] Edit `./tests/modules/nf-scil/<category>/<tool>/main.nf`
  - [x] Edit `./tests/modules/nf-scil/<category>/<tool>/nextflow.config`
  - [x] Add test data locally for tests with the fork repository
  - [x] Generate the test infrastructure and _md5sum_ for all outputs
- Ensure the syntax is correct :
  - [x] Check indentation abides with the rest of the library (don't hesitate to correct others !)
  - [x] Lint everything. Ensure your variables have good names.

## To Do 