### PR TITLE
correction for extractb0 scilpy version and topup stub prefix

### DIFF
--- a/modules/nf-neuro/preproc/topup/main.nf
+++ b/modules/nf-neuro/preproc/topup/main.nf
@@ -75,6 +75,7 @@ process PREPROC_TOPUP {
     stub:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def prefix_topup = task.ext.prefix_topup ? task.ext.prefix_topup : ""
 
     """
     scil_volume_math.py -h

--- a/modules/nf-neuro/utils/extractb0/main.nf
+++ b/modules/nf-neuro/utils/extractb0/main.nf
@@ -3,8 +3,8 @@ process UTILS_EXTRACTB0 {
     label 'process_single'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://scil.usherbrooke.ca/containers/scilus_2.0.1.sif':
-        'scilus/scilus:2.0.1' }"
+        'https://scil.usherbrooke.ca/containers/scilus_2.0.2.sif':
+        'scilus/scilus:2.0.2' }"
 
     input:
     tuple val(meta), path(dwi), path(bval), path(bvec)


### PR DESCRIPTION
Modules changes : 

Update versions in utils/extractb0. (@Manonedde)
Add the correct prefix_topup in the stub section in the topup module. (@Manonedde)

Everything is good locally...
