### PR TITLE
Split transforms into 2 inputs and update versions in `registrations/antsapplytransforms`

### DIFF
--- a/modules/nf-neuro/registration/antsapplytransforms/meta.yml
+++ b/modules/nf-neuro/registration/antsapplytransforms/meta.yml
@@ -27,10 +27,15 @@ input:
       description: Reference image for registration
       pattern: "*.{nii.nii.gz}"
 
-  - transform:
+  - warp:
       type: file
-      description: file or tuple of files, transformation file(s) to warp image or trk (*mat or [nii Warp, mat file]). If a rigid or affine transformation needs to be inverted before being applied, use antsApplyTransforms with the  -o Linear[inversedTransform,1], as this module does not handles it.
-      pattern: "*.{nii,nii.gz,mat}"
+      description: Warp transformation file to warp image or trk.
+      pattern: "*.{nii,nii.gz}"
+
+  - affine:
+      type: file
+      description: Affine or rigig transformation file to warp image or trk (*mat). If a rigid or affine transformation needs to be inverted before being applied, use antsApplyTransforms with the  -o Linear[inversedTransform,1], as this module does not handles it.
+      pattern: "*.mat"
 
 output:
   - meta:

--- a/modules/nf-neuro/registration/antsapplytransforms/tests/main.nf.test
+++ b/modules/nf-neuro/registration/antsapplytransforms/tests/main.nf.test
@@ -17,7 +17,7 @@ nextflow_process {
                 script "../../../../../subworkflows/nf-neuro/load_test_data/main.nf"
                 process {
                     """
-                    input[0] = Channel.from( [ "bst.zip" ] )
+                    input[0] = Channel.from( [ "registration.zip" ] )
                     input[1] = "test.load-test-data"
                     """
                 }
@@ -25,15 +25,19 @@ nextflow_process {
         }
 
     test("registration - antsapplytransforms") {
+
+        config "./nextflow.config"
+
         when {
             process {
                 """
                 input[0] = LOAD_DATA.out.test_data_directory
                     .map{ test_data_directory -> [
                         [ id:'test', single_end:false ], // meta map
-                        file("\${test_data_directory}/fa.nii.gz"),
-                        file("\${test_data_directory}/mask.nii.gz"),
-                        file("\${test_data_directory}/output1InverseWarp.nii.gz")
+                        file("\${test_data_directory}/b0.nii.gz"),
+                        file("\${test_data_directory}/mni_masked_2x2x2.nii.gz"),
+                        file("\${test_data_directory}/output1Warp.nii.gz"),
+                        file("\${test_data_directory}/output0GenericAffine.mat")
                     ]}
                 """
             }
@@ -42,6 +46,34 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("registration - antsapplytransforms - stub-run") {
+
+        options "-stub-run"
+
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                input[0] = LOAD_DATA.out.test_data_directory
+                    .map{ test_data_directory -> [
+                        [ id:'test', single_end:false ], // meta map
+                        file("\${test_data_directory}/b0.nii.gz"),
+                        file("\${test_data_directory}/mni_masked_2x2x2.nii.gz"),
+                        file("\${test_data_directory}/output1Warp.nii.gz"),
+                        file("\${test_data_directory}/output0GenericAffine.mat")
+                    ]}
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.versions).match() }
             )
         }
     }

--- a/modules/nf-neuro/registration/antsapplytransforms/tests/main.nf.test.snap
+++ b/modules/nf-neuro/registration/antsapplytransforms/tests/main.nf.test.snap
@@ -8,14 +8,14 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test__warped.nii.gz:md5,f5df5ab8622bfd2f3ea4c59e3c4f482e"
+                        "test__b0__warped.nii.gz:md5,3ae49aacab66fb2378da92155453b1be"
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,f45b96ead53b75f1fc565461836b1475"
+                    "versions.yml:md5,180609e91d7d492cd7db9b09f47f055d"
                 ],
                 "versions": [
-                    "versions.yml:md5,f45b96ead53b75f1fc565461836b1475"
+                    "versions.yml:md5,180609e91d7d492cd7db9b09f47f055d"
                 ],
                 "warped_image": [
                     [
@@ -23,7 +23,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test__warped.nii.gz:md5,f5df5ab8622bfd2f3ea4c59e3c4f482e"
+                        "test__b0__warped.nii.gz:md5,3ae49aacab66fb2378da92155453b1be"
                     ]
                 ]
             }
@@ -32,6 +32,18 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-25T18:07:26.443335534"
+        "timestamp": "2024-11-28T20:21:53.029255208"
+    },
+    "registration - antsapplytransforms - stub-run": {
+        "content": [
+            [
+                "versions.yml:md5,180609e91d7d492cd7db9b09f47f055d"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-11-28T20:21:57.642570655"
     }
 }

--- a/modules/nf-neuro/registration/antsapplytransforms/tests/nextflow.config
+++ b/modules/nf-neuro/registration/antsapplytransforms/tests/nextflow.config
@@ -1,5 +1,10 @@
 process {
     withName: "REGISTRATION_ANTSAPPLYTRANSFORMS" {
         ext.interpolation = "linear"
+        ext.first_suffix = "b0"
+        ext.dimensionality = 3
+        ext.image_type = 0
+        ext.output_dtype = "float"
+        ext.default_val = 0
     }
 }


### PR DESCRIPTION
Splitted the transform files in input into two different inputs, making it easier when combining it with other modules. Also, cleaned up the module and added a `-stub-run` test case.