### PR TITLE
[ENH] Update registration subworkflows and modules

### DIFF
--- a/modules/nf-neuro/registration/convert/main.nf
+++ b/modules/nf-neuro/registration/convert/main.nf
@@ -6,11 +6,11 @@ process REGISTRATION_CONVERT {
     containerOptions "--env FSLOUTPUTTYPE='NIFTI_GZ'"
 
     input:
-    tuple val(meta), path(affine), path(deform), path(source), path(target), path(fs_license)
+    tuple val(meta), path(deform), path(affine), path(source), path(target), path(fs_license)
 
     output:
-    tuple val(meta), path("*.{txt,lta,mat,dat}"), emit: affine_transform
-    tuple val(meta), path("*.{nii,nii.gz,mgz,m3z}"), emit: deform_transform
+    tuple val(meta), path("*out_deform_warp.{nii,nii.gz,mgz,m3z}") , emit: deform_transform
+    tuple val(meta), path("*out_affine_warp.{txt,lta,mat,dat}")    , emit: affine_transform, optional: true
     path "versions.yml"           , emit: versions
 
     when:
@@ -40,15 +40,20 @@ process REGISTRATION_CONVERT {
 
     cp $fs_license \$FREESURFER_HOME/license.txt
 
-    declare -A affine_dictionnary=( ["--outlta"]="lta" \
-                                    ["--outfsl"]="mat" \
-                                    ["--outmni"]="xfm" \
-                                    ["--outreg"]="dat" \
-                                    ["--outniftyreg"]="txt" \
-                                    ["--outitk"]="txt" \
-                                    ["--outvox"]="txt" )
+    if [[ -f "$affine" ]];
+    then
+        declare -A affine_dictionnary=( ["--outlta"]="lta" \
+                                        ["--outfsl"]="mat" \
+                                        ["--outmni"]="xfm" \
+                                        ["--outreg"]="dat" \
+                                        ["--outniftyreg"]="txt" \
+                                        ["--outitk"]="txt" \
+                                        ["--outvox"]="txt" )
 
-    ext_affine=\${affine_dictionnary[${out_format_affine}]}
+        ext_affine=\${affine_dictionnary[${out_format_affine}]}
+
+        lta_convert ${invert} ${source_geometry_affine} ${target_geometry_affine} ${in_format_affine} ${out_format_affine} ${prefix}__out_affine_warp.\${ext_affine}
+    fi
 
     declare -A deform_dictionnary=( ["--outm3z"]="m3z" \
                                     ["--outfsl"]="nii.gz" \
@@ -59,14 +64,13 @@ process REGISTRATION_CONVERT {
 
     ext_deform=\${deform_dictionnary[${out_format_deform}]}
 
-    lta_convert ${invert} ${source_geometry_affine} ${target_geometry_affine} ${in_format_affine} ${out_format_affine} ${prefix}__affine_warp.\${ext_affine}
-    mri_warp_convert ${source_geometry_deform} ${downsample} ${in_format_deform} ${out_format_deform}  ${prefix}__deform_warp.\${ext_deform}
+    mri_warp_convert ${source_geometry_deform} ${downsample} ${in_format_deform} ${out_format_deform}  ${prefix}__out_deform_warp.\${ext_deform}
 
     rm \$FREESURFER_HOME/license.txt
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        Freesurfer: 7.4.1
+        Freesurfer: \$(mri_convert -version | grep "freesurfer" | sed -E 's/.* ([0-9]+\\.[0-9]+\\.[0-9]+).*/\\1/')
     END_VERSIONS
     """
 
@@ -78,12 +82,12 @@ process REGISTRATION_CONVERT {
     lta_convert -h
     mri_warp_convert -h
 
-    touch ${prefix}__affine_transform.txt
     touch ${prefix}__deform_transform.nii.gz
+    touch ${prefix}__affine_transform.txt
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        Freesurfer: 7.4.1
+        Freesurfer: \$(mri_convert -version | grep "freesurfer" | sed -E 's/.* ([0-9]+\\.[0-9]+\\.[0-9]+).*/\\1/')
     END_VERSIONS
     """
 }

--- a/modules/nf-neuro/registration/convert/meta.yml
+++ b/modules/nf-neuro/registration/convert/meta.yml
@@ -19,15 +19,15 @@ input:
         Groovy Map containing sample information
         e.g. `[ id:'test', single_end:false ]`
 
-  - affine:
-      type: file
-      description: Affine transform to convert. Default usage expects Freesurfer .lta format from mri_synthmorph
-      pattern: "*.{lta,txt,xfm,dat}"
-
   - deform:
       type: file
       description: Deform transform to convert. Default usage expects Freesurfer .mgz format from mri_synthmorph
       pattern: "*.{nii,nii.gz,mgz,m3z}"
+
+  - affine:
+      type: file
+      description: Affine transform to convert. Default usage expects Freesurfer .lta format from mri_synthmorph
+      pattern: "*.{lta,txt,xfm,dat}"
 
   - source:
       type: file
@@ -51,15 +51,15 @@ output:
         Groovy Map containing sample information
         e.g. `[ id:'test', single_end:false ]`
 
-  - affine_transform:
-      type: file
-      description: Affine transform. Default usage outputs ANTs (ITK) format .txt
-      pattern: "*.{txt,lta,mat,dat}"
-
   - deform_transform:
       type: file
       description: Deform transform. Default usage outputs ANTs (ITK) format .nii.gz
       pattern: "*.{nii,nii.gz,mgz,m3z}"
+
+  - affine_transform:
+      type: file
+      description: Affine transform. Default usage outputs ANTs (ITK) format .txt
+      pattern: "*.{txt,lta,mat,dat}"
 
   - versions:
       type: file

--- a/modules/nf-neuro/registration/convert/tests/main.nf.test
+++ b/modules/nf-neuro/registration/convert/tests/main.nf.test
@@ -41,8 +41,8 @@ nextflow_process {
                 ch_transforms = ch_split_test_data.transforms.map{
                     test_data_directory -> [
                         [ id:'test' ],
-                        file("\${test_data_directory}/fs_affine.lta"),
                         file("\${test_data_directory}/fs_deform.nii.gz"),
+                        []
                     ]
                 }
                 ch_reslice = ch_split_test_data.reslice.map{
@@ -50,6 +50,54 @@ nextflow_process {
                         [ id:'test' ],
                         file("\${test_data_directory}/t1_reslice.nii.gz"),
                         []
+                    ]
+                }
+                ch_freesurfer = ch_split_test_data.freesurfer.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/license.txt")
+                    ]
+                }
+                input[0] = ch_transforms
+                    .join(ch_reslice)
+                    .join(ch_freesurfer)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("registration - convert - affine") {
+
+        config "./nextflow_default.config"
+
+        when {
+            process {
+                """
+                ch_split_test_data = LOAD_DATA.out.test_data_directory
+                    .branch{
+                        freesurfer: it.simpleName == "freesurfer"
+                        reslice: it.simpleName == "freesurfer_reslice"
+                        transforms: it.simpleName == "freesurfer_transforms"
+                    }
+                ch_transforms = ch_split_test_data.transforms.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/fs_deform.nii.gz"),
+                        file("\${test_data_directory}/fs_affine.lta")
+                    ]
+                }
+                ch_reslice = ch_split_test_data.reslice.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/t1_reslice.nii.gz"),
+                        file("\${test_data_directory}/fa_reslice.nii.gz")
                     ]
                 }
                 ch_freesurfer = ch_split_test_data.freesurfer.map{
@@ -89,8 +137,8 @@ nextflow_process {
                 ch_transforms = ch_split_test_data.transforms.map{
                     test_data_directory -> [
                         [ id:'test' ],
-                        file("\${test_data_directory}/fs_affine.lta"),
-                        file("\${test_data_directory}/fs_deform.nii.gz")
+                        file("\${test_data_directory}/fs_deform.nii.gz"),
+                        file("\${test_data_directory}/fs_affine.lta")
                     ]
                 }
                 ch_reslice = ch_split_test_data.reslice.map{
@@ -137,8 +185,8 @@ nextflow_process {
                 ch_transforms = ch_split_test_data.transforms.map{
                     test_data_directory -> [
                         [ id:'test' ],
-                        file("\${test_data_directory}/fsl_affine.mat"),
-                        file("\${test_data_directory}/fsl_deform.nii.gz")
+                        file("\${test_data_directory}/fsl_deform.nii.gz"),
+                        file("\${test_data_directory}/fsl_affine.mat")
                     ]
                 }
                 ch_reslice = ch_split_test_data.reslice.map{
@@ -189,8 +237,8 @@ nextflow_process {
                 ch_transforms = ch_split_test_data.transforms.map{
                     test_data_directory -> [
                         [ id:'test' ],
-                        file("\${test_data_directory}/fsl_affine.mat"),
-                        file("\${test_data_directory}/fsl_deform.nii.gz")
+                        file("\${test_data_directory}/fsl_deform.nii.gz"),
+                        file("\${test_data_directory}/fsl_affine.mat")
                     ]
                 }
                 ch_reslice = ch_split_test_data.reslice.map{
@@ -237,8 +285,8 @@ nextflow_process {
                 ch_transforms = ch_split_test_data.transforms.map{
                     test_data_directory -> [
                         [ id:'test' ],
-                        file("\${test_data_directory}/ants_affine.txt"),
-                        file("\${test_data_directory}/ants_deform.nii.gz")
+                        file("\${test_data_directory}/ants_deform.nii.gz"),
+                        file("\${test_data_directory}/ants_affine.txt")
                     ]
                 }
                 ch_reslice = ch_split_test_data.reslice.map{

--- a/modules/nf-neuro/registration/convert/tests/main.nf.test.snap
+++ b/modules/nf-neuro/registration/convert/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "test"
                         },
-                        "test__affine_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
+                        "test__out_deform_warp.nii.gz:md5,69052e6226da946bad1f9466285cbb89"
                     ]
                 ],
                 "1": [
@@ -15,7 +15,7 @@
                         {
                             "id": "test"
                         },
-                        "test__deform_warp.nii.gz:md5,69052e6226da946bad1f9466285cbb89"
+                        "test__out_affine_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
                     ]
                 ],
                 "2": [
@@ -26,7 +26,7 @@
                         {
                             "id": "test"
                         },
-                        "test__affine_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
+                        "test__out_affine_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
                     ]
                 ],
                 "deform_transform": [
@@ -34,7 +34,7 @@
                         {
                             "id": "test"
                         },
-                        "test__deform_warp.nii.gz:md5,69052e6226da946bad1f9466285cbb89"
+                        "test__out_deform_warp.nii.gz:md5,69052e6226da946bad1f9466285cbb89"
                     ]
                 ],
                 "versions": [
@@ -46,7 +46,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-09-24T20:50:14.250271"
+        "timestamp": "2024-10-29T14:22:02.235387011"
     },
     "registration - convert - default": {
         "content": [
@@ -56,34 +56,24 @@
                         {
                             "id": "test"
                         },
-                        "test__affine_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
+                        "test__out_deform_warp.nii.gz:md5,69052e6226da946bad1f9466285cbb89"
                     ]
                 ],
                 "1": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test__deform_warp.nii.gz:md5,69052e6226da946bad1f9466285cbb89"
-                    ]
+                    
                 ],
                 "2": [
                     "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
                 ],
                 "affine_transform": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test__affine_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
-                    ]
+                    
                 ],
                 "deform_transform": [
                     [
                         {
                             "id": "test"
                         },
-                        "test__deform_warp.nii.gz:md5,69052e6226da946bad1f9466285cbb89"
+                        "test__out_deform_warp.nii.gz:md5,69052e6226da946bad1f9466285cbb89"
                     ]
                 ],
                 "versions": [
@@ -95,17 +85,17 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-09-24T20:50:09.870665"
+        "timestamp": "2024-10-29T14:21:53.170226694"
     },
     "registration - convert - antsfs": {
         "content": [
-            "test__affine_warp.lta",
+            "test__out_affine_warp.lta",
             [
                 [
                     {
                         "id": "test"
                     },
-                    "test__deform_warp.nii.gz:md5,599fbe3a6b85d61c0c67cea8be4972b7"
+                    "test__out_deform_warp.nii.gz:md5,599fbe3a6b85d61c0c67cea8be4972b7"
                 ]
             ],
             [
@@ -116,7 +106,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-09-24T20:50:44.315777"
+        "timestamp": "2024-10-29T14:22:34.546835256"
     },
     "registration - convert - fslants": {
         "content": [
@@ -126,7 +116,7 @@
                         {
                             "id": "test"
                         },
-                        "test__affine_warp.txt:md5,074e8ac5777a91ba0808cd58c5a0cc44"
+                        "test__out_deform_warp.nii.gz:md5,94feb8f0e648256eaa5ae0a47e5702c6"
                     ]
                 ],
                 "1": [
@@ -134,7 +124,7 @@
                         {
                             "id": "test"
                         },
-                        "test__deform_warp.nii.gz:md5,94feb8f0e648256eaa5ae0a47e5702c6"
+                        "test__out_affine_warp.txt:md5,074e8ac5777a91ba0808cd58c5a0cc44"
                     ]
                 ],
                 "2": [
@@ -145,7 +135,7 @@
                         {
                             "id": "test"
                         },
-                        "test__affine_warp.txt:md5,074e8ac5777a91ba0808cd58c5a0cc44"
+                        "test__out_affine_warp.txt:md5,074e8ac5777a91ba0808cd58c5a0cc44"
                     ]
                 ],
                 "deform_transform": [
@@ -153,7 +143,7 @@
                         {
                             "id": "test"
                         },
-                        "test__deform_warp.nii.gz:md5,94feb8f0e648256eaa5ae0a47e5702c6"
+                        "test__out_deform_warp.nii.gz:md5,94feb8f0e648256eaa5ae0a47e5702c6"
                     ]
                 ],
                 "versions": [
@@ -165,17 +155,66 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-09-24T20:50:39.752948"
+        "timestamp": "2024-10-29T14:22:29.816461809"
+    },
+    "registration - convert - affine": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__out_deform_warp.nii.gz:md5,69052e6226da946bad1f9466285cbb89"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__out_affine_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
+                ],
+                "affine_transform": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__out_affine_warp.txt:md5,5f989a979be61faa578ad619377a8a07"
+                    ]
+                ],
+                "deform_transform": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test__out_deform_warp.nii.gz:md5,69052e6226da946bad1f9466285cbb89"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9912ec095965c1ff571f77b447c18f92"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-10-29T14:21:57.659285869"
     },
     "registration - convert - fslfs": {
         "content": [
-            "test__affine_warp.lta",
+            "test__out_affine_warp.lta",
             [
                 [
                     {
                         "id": "test"
                     },
-                    "test__deform_warp.nii.gz:md5,df432a27c586e57cad93af7509941cd4"
+                    "test__out_deform_warp.nii.gz:md5,df432a27c586e57cad93af7509941cd4"
                 ]
             ],
             [
@@ -186,6 +225,6 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-09-24T20:50:26.951153"
+        "timestamp": "2024-10-29T14:22:16.112616307"
     }
 }

--- a/modules/nf-neuro/registration/synthregistration/main.nf
+++ b/modules/nf-neuro/registration/synthregistration/main.nf
@@ -39,7 +39,7 @@ process REGISTRATION_SYNTHREGISTRATION {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        Synthmoprh: 3
+        synthmoprh: 3
     END_VERSIONS
     """
 
@@ -56,7 +56,7 @@ process REGISTRATION_SYNTHREGISTRATION {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        Freesurfer: 7.4.1
+        synthmoprh: 3
     END_VERSIONS
     """
 }

--- a/modules/nf-neuro/registration/synthregistration/main.nf
+++ b/modules/nf-neuro/registration/synthregistration/main.nf
@@ -1,17 +1,16 @@
 process REGISTRATION_SYNTHREGISTRATION {
     tag "$meta.id"
-    label 'process_single'
+    label 'process_high'
 
     container "freesurfer/synthmorph:3"
-    containerOptions "--entrypoint ''"
+    containerOptions "--entrypoint '' --env PYTHONPATH='/freesurfer/env/lib/python3.11/site-packages'"
 
     input:
     tuple val(meta), path(moving), path(fixed)
 
     output:
-    tuple val(meta), path("*__output_warped.nii.gz"), emit: warped_image
-    tuple val(meta), path("*__affine_warp.lta"), emit: affine_transform
-    tuple val(meta), path("*__deform_warp.nii.gz"), emit: deform_transform
+    tuple val(meta), path("*__output_warped.nii.gz")                                , emit: warped_image
+    tuple val(meta), path("*__deform_warp.nii.gz"), path("*__affine_warp.lta")      , emit: transfo_image
     path "versions.yml"           , emit: versions
 
     when:
@@ -40,7 +39,7 @@ process REGISTRATION_SYNTHREGISTRATION {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        Freesurfer: 7.4
+        Synthmoprh: 3
     END_VERSIONS
     """
 
@@ -52,12 +51,12 @@ process REGISTRATION_SYNTHREGISTRATION {
     mri_synthmorph -h
 
     touch ${prefix}__output_warped.nii.gz
-    touch ${prefix}__affine_warp.lta
     touch ${prefix}__deform_warp.nii.gz
+    touch ${prefix}__affine_warp.lta
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        Freesurfer: 7.4
+        Freesurfer: 7.4.1
     END_VERSIONS
     """
 }

--- a/modules/nf-neuro/registration/synthregistration/meta.yml
+++ b/modules/nf-neuro/registration/synthregistration/meta.yml
@@ -37,20 +37,15 @@ output:
         Groovy Map containing sample information
         e.g. `[ id:'test', single_end:false ]`
 
-  - affine_transform:
-      type: file
-      description: Affine transform for initialization
-      pattern: "*.{lta}"
-
-  - deform_transform:
-      type: file
-      description: Deform transformation
-      pattern: "*.{nii.gz}"
-
   - warped_image:
       type: file
       description: Warped image
       pattern: "*.{nii,.nii.gz}"
+
+  - transfo_image:
+      type: list
+      description: Tuple, Transformation files to warp images (nii.gz warp, lta file)
+      pattern: "*.{nii,nii.gz,lta}"
 
   - versions:
       type: file

--- a/modules/nf-neuro/registration/synthregistration/tests/main.nf.test
+++ b/modules/nf-neuro/registration/synthregistration/tests/main.nf.test
@@ -46,8 +46,7 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     file(process.out.warped_image.get(0).get(1)).name,
-                    file(process.out.affine_transform.get(0).get(1)).name,
-                    file(process.out.deform_transform.get(0).get(1)).name,
+                    file(process.out.transfo_image.get(0).get(1)).name,
                     process.out.versions
                 ).match() }
             )

--- a/modules/nf-neuro/registration/synthregistration/tests/main.nf.test.snap
+++ b/modules/nf-neuro/registration/synthregistration/tests/main.nf.test.snap
@@ -2,16 +2,15 @@
     "registration - synthregistration": {
         "content": [
             "test__output_warped.nii.gz",
-            "test__affine_warp.lta",
             "test__deform_warp.nii.gz",
             [
-                "versions.yml:md5,49fb9c85da9f696926d1ab46ef0968fb"
+                "versions.yml:md5,34dacaa82c0a03ab111bdfe8f1d692f7"
             ]
         ],
         "meta": {
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-01T22:36:18.972035"
+        "timestamp": "2024-10-30T18:08:53.765658701"
     }
 }

--- a/modules/nf-neuro/registration/synthregistration/tests/main.nf.test.snap
+++ b/modules/nf-neuro/registration/synthregistration/tests/main.nf.test.snap
@@ -4,7 +4,7 @@
             "test__output_warped.nii.gz",
             "test__deform_warp.nii.gz",
             [
-                "versions.yml:md5,34dacaa82c0a03ab111bdfe8f1d692f7"
+                "versions.yml:md5,5140205cdb117e3eb8cd4e28277f9291"
             ]
         ],
         "meta": {

--- a/subworkflows/nf-neuro/registration/main.nf
+++ b/subworkflows/nf-neuro/registration/main.nf
@@ -8,58 +8,63 @@ params.run_synthmorph   = false
 
 workflow REGISTRATION {
 
-    // ** The subworkflow requires at least ch_image and ch_ref as inputs to ** //
-    // ** properly perform the registration. Supplying a ch_metric will select ** //
-    // ** the REGISTRATION_ANATTODWI module meanwhile NOT supplying a ch_metric ** //
-    // ** will select the REGISTRATION_ANTS (SyN or SyNQuick) module. Alternatively, ** //
-    // ** NOT supplying ch_metric and activating alternative module flag with select REGISTRATION_EASYREG or REGISTRATION_SYNTHMORPH ** //
+    // The subworkflow requires at least ch_image and ch_ref as inputs to
+    // properly perform the registration. Supplying a ch_metric will select
+    // the REGISTRATION_ANATTODWI module meanwhile NOT supplying a ch_metric
+    // will select the REGISTRATION_ANTS (SyN or SyNQuick) module. Alternatively,
+    // NOT supplying ch_metric and activating alternative module flag with select
+    // REGISTRATION_EASYREG or REGISTRATION_SYNTHMORPH
 
     take:
-        ch_image                  // channel: [ val(meta), [ image ] ]
-        ch_ref                    // channel: [ val(meta), [ ref ] ]
-        ch_metric                 // channel: [ val(meta), [ metric ] ], optional
-        ch_mask                   // channel: [ val(meta), [ mask ] ], optional
-        ch_segmentation           // channel: [ val(meta), [ flo_segmentation ] ], optional
-        ch_ref_segmentation       // channel: [ val(meta), [ ref_segmentation ] ], optional
+        ch_image                // channel: [ val(meta), image ]
+        ch_ref                  // channel: [ val(meta), reference ]
+        ch_metric               // channel: [ val(meta), metric ], optional
+        ch_mask                 // channel: [ val(meta), mask ], optional
+        ch_segmentation         // channel: [ val(meta), segmentation ], optional
+        ch_ref_segmentation     // channel: [ val(meta), ref-segmentation ], optional
 
     main:
 
         ch_versions = Channel.empty()
 
         if ( params.run_easyreg ) {
-            // ** Set up input channel ** //
-            ch_register = ch_ref.join(ch_image, remainder: true)
-                                .join(ch_ref_segmentation, remainder: true)
-                                .join(ch_segmentation, remainder: true)
-                                .map{ it[0..2] + [it[3] ?: []] + [it[4] ?: []] }
-
-
             // ** Registration using Easyreg ** //
+            // Result : [ meta, reference, image | [], ref-segmentation | [], segmentation | [] ]
+            //  Steps :
+            //   - join [ meta, reference, image | null ]
+            //   - join [ meta, reference, image | null, ref-segmentation | null ]
+            //   - join [ meta, reference, image | null, ref-segmentation | null, segmentation | null ]
+            //   -  map [ meta, reference, image | [], ref-segmentation | [], segmentation | [] ]
+            ch_register = ch_ref
+                .join(ch_image, remainder: true)
+                .join(ch_ref_segmentation, remainder: true)
+                .join(ch_segmentation, remainder: true)
+                .map{ it[0..1] + [it[2] ?: [], it[3] ?: [], it[4] ?: []] }
+
             REGISTRATION_EASYREG ( ch_register )
             ch_versions = ch_versions.mix(REGISTRATION_EASYREG.out.versions.first())
 
-            // ** Setting outputs ** //
+            // ** Set compulsory outputs ** //
             image_warped = REGISTRATION_EASYREG.out.flo_reg
             transfo_image = REGISTRATION_EASYREG.out.fwd_field
             transfo_trk = REGISTRATION_EASYREG.out.bak_field
             ref_warped = REGISTRATION_EASYREG.out.ref_reg
 
-            // ** Setting optional outputs. If segmentations are not provided as inputs, ** //
-            // ** easyreg will outputs synthseg segmentations ** //
+            // ** Set optional outputs. ** //
+            // If segmentations are not provided as inputs,
+            // easyreg will outputs synthseg segmentations
             out_segmentation = ch_segmentation.mix( REGISTRATION_EASYREG.out.flo_seg )
             out_ref_segmentation = ch_ref_segmentation.mix( REGISTRATION_EASYREG.out.ref_seg )
-
         }
-
         else if ( params.run_synthmorph ) {
-            // ** Set up input channel ** //
-            ch_register = ch_image.join(ch_ref)
-
             // ** Registration using synthmorph ** //
+            ch_register = ch_image
+                .join(ch_ref)
+
             REGISTRATION_SYNTHREGISTRATION ( ch_register )
             ch_versions = ch_versions.mix(REGISTRATION_SYNTHREGISTRATION.out.versions.first())
 
-            // ** Setting outputs ** //
+            // ** Set outputs ** //
             image_warped = REGISTRATION_SYNTHREGISTRATION.out.warped_image
             transfo_image = REGISTRATION_SYNTHREGISTRATION.out.transfo_image
             transfo_trk = Channel.empty()
@@ -67,54 +72,65 @@ workflow REGISTRATION {
             out_segmentation = Channel.empty()
             out_ref_segmentation = Channel.empty()
         }
-
         else {
-            if ( ch_metric ) {
-                // ** Set up input channel ** //
-                ch_register =   ch_image.combine(ch_ref, by: 0)
-                                        .combine(ch_metric, by: 0)
+            // ** Classic registration using antsRegistration  ** //
+            // Result : [ meta, image, reference, metric | [] ]
+            //  Steps :
+            //   - join [ meta, image, ref ]
+            //   - join [ meta, image, ref, metric | null ]
+            //   - map  [ meta, image, ref, metric | [] ]
+            // Branches :
+            //   - anat_to_dwi : has a metric at index 3
+            //   - ants_syn    : doesn't have a metric at index 3 ( [] or null )
+            ch_register = ch_image
+                .join(ch_ref)
+                .join(ch_metric, remainder: true)
+                .map{ it[0..2] + [it[3] ?: []] }
+                .branch{
+                    anat_to_dwi : it[3]
+                    ants_syn: true
+                }
 
-                // ** Registration using AntsRegistration ** //
-                REGISTRATION_ANATTODWI ( ch_register )
-                ch_versions = ch_versions.mix(REGISTRATION_ANATTODWI.out.versions.first())
+            // ** Registration using ANAT TO DWI ** //
+            REGISTRATION_ANATTODWI ( ch_register.anat_to_dwi )
+            ch_versions = ch_versions.mix(REGISTRATION_ANATTODWI.out.versions.first())
 
-                // ** Setting outputs ** //
-                image_warped = REGISTRATION_ANATTODWI.out.t1_warped
-                transfo_image = REGISTRATION_ANATTODWI.out.transfo_image
-                transfo_trk = REGISTRATION_ANATTODWI.out.transfo_trk
-                ref_warped = Channel.empty()
-                out_segmentation = Channel.empty()
-                out_ref_segmentation = Channel.empty()
+            // ** Set compulsory outputs ** //
+            image_warped = REGISTRATION_ANATTODWI.out.t1_warped
+            transfo_image = REGISTRATION_ANATTODWI.out.transfo_image
+            transfo_trk = REGISTRATION_ANATTODWI.out.transfo_trk
 
-            }
-            else {
-                ch_register = ch_ref.join(ch_image, remainder: true)
-                                    .join(ch_mask, remainder: true)
-                                    .map{ it[0..2] + [it[3] ?: []] }
+            // ** Registration using ANTS SYN SCRIPTS ** //
+            // Registration using antsRegistrationSyN.sh or antsRegistrationSyNQuick.sh, has
+            // to be defined in the config file or else the default (SyN) will be used.
+            // Result : [ meta, image, mask | [] ]
+            //  Steps :
+            //   - join [ meta, image, metric | [], mask | null ]
+            //   - map  [ meta, image, mask | [] ]
+            ch_register = ch_register.ants_syn
+                .join(ch_mask, remainder: true)
+                .map{ it[0..2] + [it[4] ?: []] }
 
-                // ** Registration using antsRegistrationSyN.sh or antsRegistrationSyNQuick.sh. ** //
-                // ** Has to be defined in the config file or else the default (SyN) will be    ** //
-                // ** used.
-                REGISTRATION_ANTS ( ch_register )
-                ch_versions = ch_versions.mix(REGISTRATION_ANTS.out.versions.first())
+            REGISTRATION_ANTS ( ch_register )
+            ch_versions = ch_versions.mix(REGISTRATION_ANTS.out.versions.first())
 
-                // ** Setting outputs ** //
-                image_warped = REGISTRATION_ANTS.out.image
-                transfo_image = REGISTRATION_ANTS.out.transfo_image
-                transfo_trk = REGISTRATION_ANTS.out.transfo_trk
-                ref_warped = Channel.empty()
-                out_segmentation = Channel.empty()
-                out_ref_segmentation = Channel.empty()
-            }
+            // ** Set compulsory outputs ** //
+            image_warped = image_warped.mix(REGISTRATION_ANTS.out.image)
+            transfo_image = transfo_image.mix(REGISTRATION_ANTS.out.transfo_image)
+            transfo_trk = transfo_trk.mix(REGISTRATION_ANTS.out.transfo_trk)
+
+            // **et optional outputs **//
+            ref_warped = Channel.empty()
+            out_segmentation = Channel.empty()
+            out_ref_segmentation = Channel.empty()
         }
 
     emit:
-        image_warped  = image_warped               // channel: [ val(meta), [ image ] ]
-        ref_warped = ref_warped                    // channel: [ val(meta), [ ref ] ]
-        transfo_image = transfo_image              // channel: [ val(meta), [ warp, <affine> ] ]
-        transfo_trk   = transfo_trk                // channel: [ val(meta), [ <inverseAffine>, inverseWarp ] ]
-        segmentation = out_segmentation            // channel: [ val(meta), [ segmentation ] ]
-        ref_segmentation = out_ref_segmentation    // channel: [ val(meta), [ ref_segmentation ] ]
-
-        versions = ch_versions                     // channel: [ versions.yml ]
+        image_warped        = image_warped            // channel: [ val(meta), image ] ]
+        ref_warped          = ref_warped              // channel: [ val(meta), ref ]
+        transfo_image       = transfo_image           // channel: [ val(meta), [ warp, <affine> ] ]
+        transfo_trk         = transfo_trk             // channel: [ val(meta), [ <inverse-affine>, inverse-warp ] ]
+        segmentation        = out_segmentation        // channel: [ val(meta), segmentation ]
+        ref_segmentation    = out_ref_segmentation    // channel: [ val(meta), ref-segmentation ]
+        versions            = ch_versions             // channel: [ versions.yml ]
 }

--- a/subworkflows/nf-neuro/registration/meta.yml
+++ b/subworkflows/nf-neuro/registration/meta.yml
@@ -7,8 +7,7 @@ description: |
       module calling AntsRegistration, with the metric as additional target.
   2)  if NO metric file is supplied, the subworkflow will use the REGISTRATION_ANTS module calling
       antsRegistrationSyN.sh or antsRegistrationSyNQuick.sh.
-  3)  alternatively, if the run_synth parameter is activated, the subworkflow will use the REGISTRATION_EASYREG module
-      calling mri_easyreg.
+  3)  alternatively, if an alternative model parameter is activated, the subworkflow will use the specified module
   This subworkflow outputs transformation files that can be used with the ANTSAPPLYTRANSFORMS module
   to warp any new image. Simply provide your moving image, reference image, and transformations files
   to the module to register a new image in the current space. Similar steps can be used to register
@@ -22,6 +21,7 @@ components:
   - registration/anattodwi
   - registration/ants
   - registration/easyreg
+  - registration/synthregistration
 input:
   - ch_image:
       type: file

--- a/subworkflows/nf-neuro/registration/tests/main.nf.test
+++ b/subworkflows/nf-neuro/registration/tests/main.nf.test
@@ -94,7 +94,7 @@ nextflow_workflow {
                         [ id:'test', single_end:false ],
                         file("\${test_data_directory}/b0.nii.gz")
                     ]}
-                input[2] = []
+                input[2] = Channel.empty()
                 input[3] = Channel.empty()
                 input[4] = Channel.empty()
                 input[5] = Channel.empty()

--- a/subworkflows/nf-neuro/registration/tests/main.nf.test
+++ b/subworkflows/nf-neuro/registration/tests/main.nf.test
@@ -13,6 +13,7 @@ nextflow_workflow {
     tag "registration"
     tag "registration/ants"
     tag "registration/easyreg"
+    tag "registration/synthregistration"
 
     tag "load_test_data"
 
@@ -150,6 +151,48 @@ nextflow_workflow {
                     file(workflow.out.transfo_trk.get(0).get(1)).name,
                     niftiMD5SUM(workflow.out.segmentation.get(0).get(1), 6),
                     file(workflow.out.ref_segmentation.get(0).get(1)).name,
+                    workflow.out.versions
+                ).match()}
+            )
+        }
+    }
+    test("registration - synthregistration") {
+        config "./nextflow_synthregistration.config"
+        when {
+            workflow {
+                """
+                ch_split_test_data = LOAD_DATA.out.test_data_directory
+                    .branch{
+                        t1w: it.simpleName == "T1w"
+                        b0: it.simpleName == "b0"
+                        dti: it.simpleName == "dti"
+                    }
+                input[0] = ch_split_test_data.t1w.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/T1w.nii.gz")
+                    ]
+                }
+                input[1] = ch_split_test_data.b0.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/b0.nii.gz")
+                    ]
+                }
+                input[2] = Channel.empty()
+                input[3] = Channel.empty()
+                input[4] = Channel.empty()
+                input[5] = Channel.empty()
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    file(workflow.out.image_warped.get(0).get(1)).name,
+                    file(workflow.out.transfo_image.get(0).get(1)).name,
                     workflow.out.versions
                 ).match()}
             )

--- a/subworkflows/nf-neuro/registration/tests/main.nf.test.snap
+++ b/subworkflows/nf-neuro/registration/tests/main.nf.test.snap
@@ -4,14 +4,14 @@
             "test__output_warped.nii.gz",
             "test__deform_warp.nii.gz",
             [
-                "versions.yml:md5,1c783c1c2568810f4a9cc7dc7e2b850e"
+                "versions.yml:md5,e53631849db3a32f2e25a0b67dac320a"
             ]
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.04.3"
         },
-        "timestamp": "2024-10-30T18:22:51.835424696"
+        "timestamp": "2024-12-04T12:59:41.626052"
     },
     "registration - easyreg": {
         "content": [
@@ -44,7 +44,7 @@
                     ]
                 ],
                 "1": [
-
+                    
                 ],
                 "2": [
                     [
@@ -67,10 +67,10 @@
                     ]
                 ],
                 "4": [
-
+                    
                 ],
                 "5": [
-
+                    
                 ],
                 "6": [
                     "versions.yml:md5,9c255f4c751382be7bf6fe6ffb0d635d"
@@ -85,13 +85,13 @@
                     ]
                 ],
                 "ref_segmentation": [
-
+                    
                 ],
                 "ref_warped": [
-
+                    
                 ],
                 "segmentation": [
-
+                    
                 ],
                 "transfo_image": [
                     [
@@ -133,11 +133,11 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test__warped.nii.gz:md5,40010055cb124e9a5e61a2565f1f5db2"
+                        "test__warped.nii.gz:md5,f7e262c9c75c651a9057d3082c2a69ad"
                     ]
                 ],
                 "1": [
-
+                    
                 ],
                 "2": [
                     [
@@ -146,8 +146,8 @@
                             "single_end": false
                         },
                         [
-                            "test__output0Warp.nii.gz:md5,790b8a076b1c146ffbb1d3ae614927d9",
-                            "test__output1GenericAffine.mat:md5,b8f7939863fdef61b97d93f2b6021e12"
+                            "test__output0Warp.nii.gz:md5,964cf7e60171214164f280452f1ae6e0",
+                            "test__output1GenericAffine.mat:md5,bfd589d2b237a20bbeef0656ecd64e14"
                         ]
                     ]
                 ],
@@ -158,16 +158,16 @@
                             "single_end": false
                         },
                         [
-                            "test__output0InverseAffine.mat:md5,966aac28b5eda0fc6299672bfbeeb3ee",
-                            "test__output1InverseWarp.nii.gz:md5,f6c7df8d65a8e31af3250bf8be5aece9"
+                            "test__output0InverseAffine.mat:md5,235417a8c7eee8ab7bde320b9e48d2f1",
+                            "test__output1InverseWarp.nii.gz:md5,fac9af1885f5e1cce39fcf06fca93dfc"
                         ]
                     ]
                 ],
                 "4": [
-
+                    
                 ],
                 "5": [
-
+                    
                 ],
                 "6": [
                     "versions.yml:md5,9fe7f597ac6c76efff8851f9b672f17b"
@@ -178,17 +178,17 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test__warped.nii.gz:md5,40010055cb124e9a5e61a2565f1f5db2"
+                        "test__warped.nii.gz:md5,f7e262c9c75c651a9057d3082c2a69ad"
                     ]
                 ],
                 "ref_segmentation": [
-
+                    
                 ],
                 "ref_warped": [
-
+                    
                 ],
                 "segmentation": [
-
+                    
                 ],
                 "transfo_image": [
                     [
@@ -197,8 +197,8 @@
                             "single_end": false
                         },
                         [
-                            "test__output0Warp.nii.gz:md5,790b8a076b1c146ffbb1d3ae614927d9",
-                            "test__output1GenericAffine.mat:md5,b8f7939863fdef61b97d93f2b6021e12"
+                            "test__output0Warp.nii.gz:md5,964cf7e60171214164f280452f1ae6e0",
+                            "test__output1GenericAffine.mat:md5,bfd589d2b237a20bbeef0656ecd64e14"
                         ]
                     ]
                 ],
@@ -209,8 +209,8 @@
                             "single_end": false
                         },
                         [
-                            "test__output0InverseAffine.mat:md5,966aac28b5eda0fc6299672bfbeeb3ee",
-                            "test__output1InverseWarp.nii.gz:md5,f6c7df8d65a8e31af3250bf8be5aece9"
+                            "test__output0InverseAffine.mat:md5,235417a8c7eee8ab7bde320b9e48d2f1",
+                            "test__output1InverseWarp.nii.gz:md5,fac9af1885f5e1cce39fcf06fca93dfc"
                         ]
                     ]
                 ],
@@ -220,9 +220,9 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.04.3"
         },
-        "timestamp": "2024-10-31T19:42:16.225779061"
+        "timestamp": "2024-12-04T13:19:52.734589"
     }
 }

--- a/subworkflows/nf-neuro/registration/tests/main.nf.test.snap
+++ b/subworkflows/nf-neuro/registration/tests/main.nf.test.snap
@@ -1,4 +1,18 @@
 {
+    "registration - synthregistration": {
+        "content": [
+            "test__output_warped.nii.gz",
+            "test__deform_warp.nii.gz",
+            [
+                "versions.yml:md5,1c783c1c2568810f4a9cc7dc7e2b850e"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-10-30T18:22:51.835424696"
+    },
     "registration - easyreg": {
         "content": [
             "test_floating_registered.nii.gz",
@@ -30,7 +44,7 @@
                     ]
                 ],
                 "1": [
-                    
+
                 ],
                 "2": [
                     [
@@ -53,10 +67,10 @@
                     ]
                 ],
                 "4": [
-                    
+
                 ],
                 "5": [
-                    
+
                 ],
                 "6": [
                     "versions.yml:md5,9c255f4c751382be7bf6fe6ffb0d635d"
@@ -71,13 +85,13 @@
                     ]
                 ],
                 "ref_segmentation": [
-                    
+
                 ],
                 "ref_warped": [
-                    
+
                 ],
                 "segmentation": [
-                    
+
                 ],
                 "transfo_image": [
                     [
@@ -123,7 +137,7 @@
                     ]
                 ],
                 "1": [
-                    
+
                 ],
                 "2": [
                     [
@@ -150,10 +164,10 @@
                     ]
                 ],
                 "4": [
-                    
+
                 ],
                 "5": [
-                    
+
                 ],
                 "6": [
                     "versions.yml:md5,9fe7f597ac6c76efff8851f9b672f17b"
@@ -168,13 +182,13 @@
                     ]
                 ],
                 "ref_segmentation": [
-                    
+
                 ],
                 "ref_warped": [
-                    
+
                 ],
                 "segmentation": [
-                    
+
                 ],
                 "transfo_image": [
                     [
@@ -209,6 +223,6 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-25T09:19:43.397585"
+        "timestamp": "2024-10-31T19:42:16.225779061"
     }
 }

--- a/subworkflows/nf-neuro/registration/tests/nextflow_synthregistration.config
+++ b/subworkflows/nf-neuro/registration/tests/nextflow_synthregistration.config
@@ -1,0 +1,12 @@
+process {
+    withName: "REGISTRATION_SYNTHREGISTRATION" {
+        publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+        memory = '20G'
+        ext.affine = "affine"
+        ext.warp = "deform"
+        ext.lambda = 0.9
+        ext.steps = 9
+    }
+}
+
+params.run_synthmorph = true


### PR DESCRIPTION
Continuation of #25

## Type of improvement

- [ ] Documentation
- [ ] Development tools (e.g. linter, formatter, etc.)
- [ ] Development container
- [ ] Global update (please specify)
- [x] Other (please specify)

## Describe your improvement

subworkflow/registration:

- add synthregistration optionality to subworkflow
- add specific test for synthregistration

modules/synthregistration:

- change output structure to tuple transfo_image containing both transforms
- add python package access. 

module/convert:

- add optionality to affine conversion. If no affine is provided, skips conversion. Synthmorph output include affine initialization in its deform output.
- change output order

## Checklist before requesting a review

- [x] Ensure the syntax is correct (**EditorConfig** and **Prettier** must pass)
- [x] Run the test suites if your changes affect any module
- [x] Regenerate the **Poetry** lock file if you have updated the dependencies
- [x] Ensure the documentation is up-to-date