### PR TITLE
#40 - Catch antsBrainExtraction.sh exit error code in stub-run + add stub test

### DIFF
--- a/modules/nf-neuro/betcrop/antsbet/main.nf
+++ b/modules/nf-neuro/betcrop/antsbet/main.nf
@@ -45,14 +45,9 @@ process BETCROP_ANTSBET {
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
 
-        """
-    antsBrainExtraction.sh -h
-    scil_volume_math.py -h
-    mrcalc -h
-
+    """
     touch ${prefix}__t1_bet.nii.gz
     touch ${prefix}__t1_bet_mask.nii.gz
 
@@ -62,5 +57,16 @@ process BETCROP_ANTSBET {
         mrtrix: \$(mrcalc -version 2>&1 | sed -n 's/== mrcalc \\([0-9.]\\+\\).*/\\1/p')
         ants: \$(antsRegistration --version | grep "Version" | sed -E 's/.*v([0-9]+\\+\\).*/\\1/')
     END_VERSIONS
+
+    function handle_code () {
+    local code=\$?
+    ignore=( 1 )
+    exit \$([[ " \${ignore[@]} " =~ " \$code " ]] && echo 0 || echo \$code)
+    }
+    trap 'handle_code' ERR
+
+    antsBrainExtraction.sh
+    scil_volume_math.py -h
+    mrcalc -h
     """
 }

--- a/modules/nf-neuro/betcrop/antsbet/tests/main.nf.test
+++ b/modules/nf-neuro/betcrop/antsbet/tests/main.nf.test
@@ -78,4 +78,71 @@ nextflow_process {
 
     }
 
+    test("betcrop - antsbet - stub-run") {
+
+        options "-stub-run"
+
+        setup {
+            run("LOAD_TEST_DATA", alias: "LOAD_DATA") {
+                script "../../../../../subworkflows/nf-neuro/load_test_data/main.nf"
+                process {
+                    """
+                    input[0] = Channel.from( [ "T1w.zip", "transform.zip", "antsbet.zip" ] )
+                    input[1] = "test.load-test-data"
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                ch_split_test_data = LOAD_DATA.out.test_data_directory
+                    .branch{
+                        t1: it.simpleName == "T1w"
+                        transform: it.simpleName == "transform"
+                        template: it.simpleName == "antsbet"
+                    }
+                ch_t1 = ch_split_test_data.t1.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/T1w.nii.gz")
+                    ]
+                }
+                ch_template = ch_split_test_data.template.map{
+                    test_data_directory -> [
+                        [ id: 'test' ],
+                        file("\${test_data_directory}/t1_template.nii.gz"),
+                        file("\${test_data_directory}/t1_brain_probability_map.nii.gz")
+                    ]
+                }
+                ch_mask = ch_split_test_data.transform.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/t1_to_bet_template_mask.nii.gz")
+                    ]
+                }
+                ch_transform = ch_split_test_data.transform.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/t1_to_bet_template.mat")
+                    ]
+                }
+                input[0] = ch_t1
+                    .join(ch_template)
+                    .join(ch_mask)
+                    .join(ch_transform)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.versions).match() }
+            )
+        }
+
+    }
+
 }

--- a/modules/nf-neuro/betcrop/antsbet/tests/main.nf.test
+++ b/modules/nf-neuro/betcrop/antsbet/tests/main.nf.test
@@ -72,7 +72,11 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    niftiMD5SUM(process.out.t1.get(0).get(1)),
+                    niftiMD5SUM(process.out.mask.get(0).get(1)),
+                    process.out.versions
+                ).match() }
             )
         }
 

--- a/modules/nf-neuro/betcrop/antsbet/tests/main.nf.test
+++ b/modules/nf-neuro/betcrop/antsbet/tests/main.nf.test
@@ -14,7 +14,6 @@ nextflow_process {
     tag "subworkflows/load_test_data"
 
     test("betcrop - antsbet") {
-
         setup {
             run("LOAD_TEST_DATA", alias: "LOAD_DATA") {
                 script "../../../../../subworkflows/nf-neuro/load_test_data/main.nf"
@@ -26,7 +25,6 @@ nextflow_process {
                 }
             }
         }
-
         when {
             process {
                 """
@@ -68,7 +66,6 @@ nextflow_process {
                 """
             }
         }
-
         then {
             assertAll(
                 { assert process.success },
@@ -79,13 +76,9 @@ nextflow_process {
                 ).match() }
             )
         }
-
     }
-
     test("betcrop - antsbet - stub-run") {
-
         options "-stub-run"
-
         setup {
             run("LOAD_TEST_DATA", alias: "LOAD_DATA") {
                 script "../../../../../subworkflows/nf-neuro/load_test_data/main.nf"
@@ -97,7 +90,6 @@ nextflow_process {
                 }
             }
         }
-
         when {
             process {
                 """
@@ -139,14 +131,11 @@ nextflow_process {
                 """
             }
         }
-
         then {
             assertAll(
                 { assert process.success },
                 { assert snapshot(process.out.versions).match() }
             )
         }
-
     }
-
 }

--- a/modules/nf-neuro/betcrop/antsbet/tests/main.nf.test.snap
+++ b/modules/nf-neuro/betcrop/antsbet/tests/main.nf.test.snap
@@ -44,8 +44,20 @@
         ],
         "meta": {
             "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nextflow": "24.10.1"
         },
-        "timestamp": "2024-10-30T17:42:18.337235926"
+        "timestamp": "2024-12-12T09:39:00.302246"
+    },
+    "betcrop - antsbet - stub-run": {
+        "content": [
+            [
+                "versions.yml:md5,9fde1445bc10857db69e440781e58cb7"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.10.1"
+        },
+        "timestamp": "2024-12-12T10:20:29.72452"
     }
 }

--- a/modules/nf-neuro/betcrop/antsbet/tests/main.nf.test.snap
+++ b/modules/nf-neuro/betcrop/antsbet/tests/main.nf.test.snap
@@ -1,52 +1,17 @@
 {
     "betcrop - antsbet": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test__t1_bet.nii.gz:md5,bd666c4ce559eab93690131f8b2a9101"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test__t1_bet_mask.nii.gz:md5,48c91d01a6c59d48e4ce84431d5e4971"
-                    ]
-                ],
-                "2": [
-                    "versions.yml:md5,9fde1445bc10857db69e440781e58cb7"
-                ],
-                "mask": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test__t1_bet_mask.nii.gz:md5,48c91d01a6c59d48e4ce84431d5e4971"
-                    ]
-                ],
-                "t1": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test__t1_bet.nii.gz:md5,bd666c4ce559eab93690131f8b2a9101"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,9fde1445bc10857db69e440781e58cb7"
-                ]
-            }
+            "test__t1_bet.nii.gz:md5:header,72167012fa8893d3c3531d5d1245b84a,data,e31b24e1dadf5b067211544fca1f3f01",
+            "test__t1_bet_mask.nii.gz:md5:header,f7389fe98c9a7e3a87c90b7ca05ea14a,data,1572808125554e50ff73fbe0e28037a9",
+            [
+                "versions.yml:md5,9fde1445bc10857db69e440781e58cb7"
+            ]
         ],
         "meta": {
             "nf-test": "0.9.0",
             "nextflow": "24.10.1"
         },
-        "timestamp": "2024-12-12T09:39:00.302246"
+        "timestamp": "2024-12-17T20:31:09.4739"
     },
     "betcrop - antsbet - stub-run": {
         "content": [


### PR DESCRIPTION
I added the trap function to catch the error code for antsBrainExtraction.sh. The function has to be placed after we fetch the versions and touch the files. If not, for some reason, it also catches the output files. Link to #40 