### PR TITLE
Restrict RAM on containers through nextflow profile

### DIFF
--- a/modules/nf-neuro/registration/synthregistration/main.nf
+++ b/modules/nf-neuro/registration/synthregistration/main.nf
@@ -33,7 +33,7 @@ process REGISTRATION_SYNTHREGISTRATION {
     export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=1
     export OMP_NUM_THREADS=1
     export OPENBLAS_NUM_THREADS=1
-
+    echo "dumb message to trigger tests for the modules"
     mri_synthmorph -j $task.cpus ${affine} -t ${prefix}__affine_warp.lta $moving $fixed
     mri_synthmorph -j $task.cpus ${warp} ${gpu} ${lambda} ${steps} ${extent} ${weight} -i ${prefix}__affine_warp.lta  -t ${prefix}__deform_warp.nii.gz -o ${prefix}__output_warped.nii.gz $moving $fixed
 

--- a/modules/nf-neuro/registration/synthregistration/main.nf
+++ b/modules/nf-neuro/registration/synthregistration/main.nf
@@ -33,7 +33,6 @@ process REGISTRATION_SYNTHREGISTRATION {
     export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=1
     export OMP_NUM_THREADS=1
     export OPENBLAS_NUM_THREADS=1
-    echo "dumb message to trigger tests for the modules"
     mri_synthmorph -j $task.cpus ${affine} -t ${prefix}__affine_warp.lta $moving $fixed
     mri_synthmorph -j $task.cpus ${warp} ${gpu} ${lambda} ${steps} ${extent} ${weight} -i ${prefix}__affine_warp.lta  -t ${prefix}__deform_warp.nii.gz -o ${prefix}__output_warped.nii.gz $moving $fixed
 

--- a/modules/nf-neuro/registration/synthregistration/tests/nextflow.config
+++ b/modules/nf-neuro/registration/synthregistration/tests/nextflow.config
@@ -1,5 +1,5 @@
 process {
-    memory = "20G"
+    memory = "32G"
     withName: "REGISTRATION_SYNTHREGISTRATION" {
         publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
         ext.affine = "affine"

--- a/subworkflows/nf-neuro/registration/tests/nextflow_synthregistration.config
+++ b/subworkflows/nf-neuro/registration/tests/nextflow_synthregistration.config
@@ -1,7 +1,7 @@
 process {
     withName: "REGISTRATION_SYNTHREGISTRATION" {
         publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
-        memory = '20G'
+        memory = '32G'
         ext.affine = "affine"
         ext.warp = "deform"
         ext.lambda = 0.9

--- a/tests/config/nextflow.config
+++ b/tests/config/nextflow.config
@@ -48,6 +48,11 @@ profiles {
         docker.fixOwnership = true
         docker.runOptions = '--platform=linux/amd64'
     }
+    docker_self_hosted_bigmem{
+        docker.enabled = true
+        docker.fixOwnership = true
+        docker.runOptions = '--platform=linux/amd64 --memory-reservation 32000000000'
+    }
 }
 
 manifest {

--- a/tests/config/nextflow.config
+++ b/tests/config/nextflow.config
@@ -51,7 +51,7 @@ profiles {
     docker_self_hosted_bigmem{
         docker.enabled = true
         docker.fixOwnership = true
-        docker.runOptions = '--platform=linux/amd64 --memory-reservation 32000000000'
+        docker.runOptions = '--platform=linux/amd64'
     }
 }
 


### PR DESCRIPTION
## Bug category

- [x] Critical (some functionalities is not working at all)
- [ ] Major (something is not working as expected)
- [ ] Minor (something but could be improved)
- [ ] Trivial (documentation needs correcting and other non-functional issues)

## Describe the bug

All tests seem to run well, except for `synthregistration`. Other ML based models seem to run correctly on the `bigmem` runners, so the cluster configurtion seems ok. There appears to be a **memory leak** inside of `synthregistration`, or maybe it doesn't manage resources by construction.

To try to prevent this, I created a new profile for runners, applied by `nextflow` through `tests/config/nextflow.config`, that sets a memory limit on the containers spawned by docker. Maybe this will restrict `synthregistration` gobbling the whole RAM.

## Steps to reproduce the bug

Current status of any tests including `synthregistration` in a PR is failed.
