### PR TITLE
Fix data type for phillips acquisition in topup module

### DIFF
--- a/modules/nf-neuro/preproc/topup/main.nf
+++ b/modules/nf-neuro/preproc/topup/main.nf
@@ -39,7 +39,7 @@ process PREPROC_TOPUP {
 
     if [[ -f "$b0" ]];
     then
-        scil_volume_math.py concatenate $b0 $b0 ${prefix}__concatenated_b0.nii.gz
+        scil_volume_math.py concatenate $b0 $b0 ${prefix}__concatenated_b0.nii.gz --data_type float32
         scil_volume_math.py mean ${prefix}__concatenated_b0.nii.gz ${prefix}__b0_mean.nii.gz
     else
         scil_dwi_extract_b0.py $dwi $bval $bvec ${prefix}__b0_mean.nii.gz --mean --b0_threshold $b0_thr_extract_b0 --skip_b0_check
@@ -47,7 +47,7 @@ process PREPROC_TOPUP {
 
     if [[ -f "$rev_b0" ]];
     then
-        scil_volume_math.py concatenate $rev_b0 $rev_b0 ${prefix}__concatenated_rev_b0.nii.gz
+        scil_volume_math.py concatenate $rev_b0 $rev_b0 ${prefix}__concatenated_rev_b0.nii.gz --data_type float32
         scil_volume_math.py mean ${prefix}__concatenated_rev_b0.nii.gz ${prefix}__rev_b0_mean.nii.gz
     else
         scil_dwi_extract_b0.py $rev_dwi $rev_bval $rev_bvec ${prefix}__rev_b0_mean.nii.gz --mean --b0_threshold $b0_thr_extract_b0 --skip_b0_check


### PR DESCRIPTION
Acquisitions on Phillips scanners were returning weird concatenated b0s in topup due to the multiplier not being properly used. Forcing `--data_type float32` in the concatenate steps solves the issue. See images below:

**Without enforcing data type:**
![image](https://github.com/user-attachments/assets/a743899b-32e2-44dc-9172-15cf9d0f5892)


**With enforcing the data type:**
![image](https://github.com/user-attachments/assets/2087706b-e55e-4fad-9a6e-aa23cc86488d)
