### PR TITLE
[WIP] Switch params from `task.ext` scope to process' inputs - Example use-case

### DIFF
--- a/modules/nf-neuro/image/powderaverage/main.nf
+++ b/modules/nf-neuro/image/powderaverage/main.nf
@@ -8,6 +8,9 @@ process IMAGE_POWDERAVERAGE {
 
     input:
         tuple val(meta), path(dwi), path(bval), path(mask)
+        val b0_thr
+        val shells
+        val shell_thr
 
     output:
         tuple val(meta), path("*pwd_avg.nii.gz")    , emit: pwd_avg
@@ -20,15 +23,15 @@ process IMAGE_POWDERAVERAGE {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
 
-    def b0_thr = task.ext.b0_thr ? "--b0_thr ${task.ext.b0_thr}" : ''
-    def shells = task.ext.shells ? "--shells ${task.ext.shells}" : ''
-    def shell_thr = task.ext.shell_thr ? "--shell_thr ${task.ext.shell_thr}" : ''
+    args += b0_thr ? "--b0_thr ${b0_thr} " : ''
+    args += shells ? "--shells ${shells} " : ''
+    args += shell_thr ? "--shell_thr ${shell_thr} " : ''
 
     if ( mask ) args += "--mask ${mask}"
 
     """
     scil_dwi_powder_average.py $dwi $bval ${prefix}_pwd_avg.nii.gz \
-        $b0_thr $shells $shell_thr $args
+        $args
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-neuro/image/powderaverage/meta.yml
+++ b/modules/nf-neuro/image/powderaverage/meta.yml
@@ -35,19 +35,20 @@ input:
   - b0_thr:
       type: integer
       description: Threshold to consider a volume as a b0.
-      default: 50
+      pattern: 50
 
   - shells:
       type: string
       description: |
         List of b-values (shells) to include in powder average passed as a list.
         If not specified, will include all volumes with a non-zero b-value.
+      pattern: "1000 2000"
 
   - shell_thr:
       type: integer
       description: |
         Threshold to consider a volume as part of a shell (b-value +- threshold).
-      default: 50
+      pattern: 50
 
 output:
   - meta:

--- a/modules/nf-neuro/image/powderaverage/meta.yml
+++ b/modules/nf-neuro/image/powderaverage/meta.yml
@@ -34,21 +34,23 @@ input:
 
   - b0_thr:
       type: integer
-      description: Threshold to consider a volume as a b0.
-      pattern: 50
+      description: "Threshold to consider a volume as a b0. (default: 50)"
+      default: 50
 
   - shells:
       type: string
       description: |
-        List of b-values (shells) to include in powder average passed as a list.
+        "List of b-values (shells) to include in powder average passed as a list.
         If not specified, will include all volumes with a non-zero b-value.
+        (default: null)"
       pattern: "1000 2000"
 
   - shell_thr:
       type: integer
       description: |
-        Threshold to consider a volume as part of a shell (b-value +- threshold).
-      pattern: 50
+        "Threshold to consider a volume as part of a shell (b-value +- threshold).
+        (default: 50)"
+      default: 50
 
 output:
   - meta:

--- a/modules/nf-neuro/image/powderaverage/meta.yml
+++ b/modules/nf-neuro/image/powderaverage/meta.yml
@@ -40,16 +40,16 @@ input:
   - shells:
       type: string
       description: |
-        "List of b-values (shells) to include in powder average passed as a list.
+        List of b-values (shells) to include in powder average passed as a list.
         If not specified, will include all volumes with a non-zero b-value.
-        (default: null)"
+        (default: null)
       pattern: "1000 2000"
 
   - shell_thr:
       type: integer
       description: |
-        "Threshold to consider a volume as part of a shell (b-value +- threshold).
-        (default: 50)"
+        Threshold to consider a volume as part of a shell (b-value +- threshold).
+        (default: 50)
       default: 50
 
 output:

--- a/modules/nf-neuro/image/powderaverage/meta.yml
+++ b/modules/nf-neuro/image/powderaverage/meta.yml
@@ -32,6 +32,23 @@ input:
       description: Binary mask to apply on the DWI volume.
       pattern: "*.nii.gz"
 
+  - b0_thr:
+      type: integer
+      description: Threshold to consider a volume as a b0.
+      default: 50
+
+  - shells:
+      type: string
+      description: |
+        List of b-values (shells) to include in powder average passed as a list.
+        If not specified, will include all volumes with a non-zero b-value.
+
+  - shell_thr:
+      type: integer
+      description: |
+        Threshold to consider a volume as part of a shell (b-value +- threshold).
+      default: 50
+
 output:
   - meta:
       type: map

--- a/modules/nf-neuro/image/powderaverage/tests/main.nf.test
+++ b/modules/nf-neuro/image/powderaverage/tests/main.nf.test
@@ -39,6 +39,9 @@ nextflow_process {
                         []
                     ]
                 }
+                input[1] = params.b0_thr
+                input[2] = params.shells
+                input[3] = params.shell_thr
                 """
             }
         }
@@ -66,6 +69,9 @@ nextflow_process {
                         file("\${test_data_directory}/dwi/mask.nii.gz")
                     ]
                 }
+                input[1] = params.b0_thr
+                input[2] = params.shells
+                input[3] = params.shell_thr
                 """
             }
         }

--- a/modules/nf-neuro/image/powderaverage/tests/nextflow_noshells.config
+++ b/modules/nf-neuro/image/powderaverage/tests/nextflow_noshells.config
@@ -1,6 +1,5 @@
-process {
-    withName: "IMAGE_POWDERAVERAGE" {
-        ext.b0_thr = 50
-        ext.shell_thr = 50
-    }
+params {
+    b0_thr = 50
+    shells = []
+    shell_thr = 50
 }

--- a/modules/nf-neuro/image/powderaverage/tests/nextflow_shells.config
+++ b/modules/nf-neuro/image/powderaverage/tests/nextflow_shells.config
@@ -1,7 +1,5 @@
-process {
-    withName: "IMAGE_POWDERAVERAGE" {
-        ext.b0_thr = 50
-        ext.shells = "1000 2000"
-        ext.shell_thr = 50
-    }
+params {
+    b0_thr = 50
+    shells = "1000 2000"
+    shell_thr = 50
 }


### PR DESCRIPTION
Following the discussion around the documentation of modules' parameters with `nf-core` people, `nextflow` will soon deprecate the use of `task.ext` to move the parameters as module inputs. This PR is an example of what it would look like so we can decide which direction we want to take.

To illustrate the change required, I move the `task.ext` params for the `image/powderaverage` module to inputs. This allows easy documentation of parameters through the `meta.yml` file, making them accessible with the `nf-core modules info` command:
![image](https://github.com/user-attachments/assets/73701bde-60d1-46c1-905d-033177cc5b00)

One downside is that when creating pipelines, we will have to handle a lot of channels, but I do not feel this is worse than dealing with the config files.

Thoughts? @Manonedde @ThoumyreStanislas @arnaudbore @AlexVCaron 