### PR TITLE
Change input definition for the topup config file.

### DIFF
--- a/modules/nf-neuro/preproc/eddy/main.nf
+++ b/modules/nf-neuro/preproc/eddy/main.nf
@@ -3,8 +3,8 @@ process PREPROC_EDDY {
     label 'process_high'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        "https://scil.usherbrooke.ca/containers/scilus_2.0.2.sif":
-        "scilus/scilus:2.0.2"}"
+        'https://scil.usherbrooke.ca/containers/scilus_2.0.2.sif':
+        'scilus/scilus:2.0.2' }"
 
     input:
         tuple val(meta), path(dwi), path(bval), path(bvec), path(rev_dwi), path(rev_bval), path(rev_bvec), path(corrected_b0s), path(topup_fieldcoef), path(topup_movpart)

--- a/modules/nf-neuro/preproc/topup/main.nf
+++ b/modules/nf-neuro/preproc/topup/main.nf
@@ -3,12 +3,12 @@ process PREPROC_TOPUP {
     label 'process_single'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        "https://scil.usherbrooke.ca/containers/scilus_2.0.2.sif":
-        "scilus/scilus:2.0.2"}"
+        'https://scil.usherbrooke.ca/containers/scilus_2.0.2.sif':
+        'scilus/scilus:2.0.2' }"
 
     input:
         tuple val(meta), path(dwi), path(bval), path(bvec), path(b0), path(rev_dwi), path(rev_bval), path(rev_bvec), path(rev_b0)
-        val(config_topup)
+        each config_topup
 
     output:
         tuple val(meta), path("*__corrected_b0s.nii.gz"), emit: topup_corrected_b0s

--- a/modules/nf-neuro/preproc/topup/main.nf
+++ b/modules/nf-neuro/preproc/topup/main.nf
@@ -8,7 +8,7 @@ process PREPROC_TOPUP {
 
     input:
         tuple val(meta), path(dwi), path(bval), path(bvec), path(b0), path(rev_dwi), path(rev_bval), path(rev_bvec), path(rev_b0)
-        each config_topup
+        val config_topup
 
     output:
         tuple val(meta), path("*__corrected_b0s.nii.gz"), emit: topup_corrected_b0s

--- a/modules/nf-neuro/preproc/topup/tests/main.nf.test
+++ b/modules/nf-neuro/preproc/topup/tests/main.nf.test
@@ -41,7 +41,7 @@ nextflow_process {
                     file("\${test_data_directory}/sub-01_dir-PA_dwi.bval", checkIfExists: true),
                     file("\${test_data_directory}/sub-01_dir-PA_dwi.bvec", checkIfExists: true),
                     file("\${test_data_directory}/sub-01_dir-PA_sbref.nii.gz", checkIfExists: true)]}
-                input[1] = ''
+                input[1] = Channel.value('')
                 """
             }
         }
@@ -76,7 +76,7 @@ nextflow_process {
                     [],
                     [],
                     file("\${test_data_directory}/sub-01_dir-PA_sbref.nii.gz", checkIfExists: true)]}
-                input[1] = ''
+                input[1] = Channel.value('')
                 """
             }
         }
@@ -112,7 +112,7 @@ nextflow_process {
                     file("\${test_data_directory}/sub-01_dir-PA_dwi.bval", checkIfExists: true),
                     file("\${test_data_directory}/sub-01_dir-PA_dwi.bvec", checkIfExists: true),
                     file("\${test_data_directory}/sub-01_dir-PA_sbref.nii.gz", checkIfExists: true)]}
-                input[1] = ''
+                input[1] = Channel.value('')
                 """
             }
         }

--- a/modules/nf-neuro/preproc/topup/tests/main.nf.test
+++ b/modules/nf-neuro/preproc/topup/tests/main.nf.test
@@ -65,17 +65,32 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = LOAD_DATA.out.test_data_directory
-                    .map{ test_data_directory -> [
-                    [ id:'test', single_end:false ], // meta map
-                    file("\${test_data_directory}/sub-01_dir-AP_dwi.nii.gz", checkIfExists: true),
-                    file("\${test_data_directory}/sub-01_dir-AP_dwi.bval", checkIfExists: true),
-                    file("\${test_data_directory}/sub-01_dir-AP_dwi.bvec", checkIfExists: true),
-                    [],
-                    [],
-                    [],
-                    [],
-                    file("\${test_data_directory}/sub-01_dir-PA_sbref.nii.gz", checkIfExists: true)]}
+                input[0] = LOAD_DATA.out.test_data_directory.flatMap { test_data_directory ->
+                        [
+                            [
+                                [ id:'test1', single_end:false ],
+                                file("\${test_data_directory}/sub-01_dir-AP_dwi.nii.gz", checkIfExists: true),
+                                file("\${test_data_directory}/sub-01_dir-AP_dwi.bval", checkIfExists: true),
+                                file("\${test_data_directory}/sub-01_dir-AP_dwi.bvec", checkIfExists: true),
+                                [],
+                                [],
+                                [],
+                                [],
+                                file("\${test_data_directory}/sub-01_dir-PA_sbref.nii.gz", checkIfExists: true)
+                            ],
+                            [
+                                [ id:'test2', single_end:false ],
+                                file("\${test_data_directory}/sub-01_dir-AP_dwi.nii.gz", checkIfExists: true),
+                                file("\${test_data_directory}/sub-01_dir-AP_dwi.bval", checkIfExists: true),
+                                file("\${test_data_directory}/sub-01_dir-AP_dwi.bvec", checkIfExists: true),
+                                [],
+                                [],
+                                [],
+                                [],
+                                file("\${test_data_directory}/sub-01_dir-PA_sbref.nii.gz", checkIfExists: true)
+                            ]
+                        ]
+                    }
                 input[1] = Channel.value('')
                 """
             }
@@ -83,6 +98,12 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
+                { assert process.out.topup_corrected_b0s.size() == 2 },
+                { assert process.out.topup_fieldcoef.size() == 2 },
+                { assert process.out.topup_movpart.size() == 2 },
+                { assert process.out.rev_b0_warped.size() == 2 },
+                { assert process.out.rev_b0_mean.size() == 2 },
+                { assert process.out.b0_mean.size() == 2 },
                 { assert snapshot(
                     file(process.out.topup_corrected_b0s.get(0).get(1)).name,
                     file(process.out.topup_fieldcoef.get(0).get(1)).name,

--- a/modules/nf-neuro/preproc/topup/tests/main.nf.test
+++ b/modules/nf-neuro/preproc/topup/tests/main.nf.test
@@ -41,7 +41,7 @@ nextflow_process {
                     file("\${test_data_directory}/sub-01_dir-PA_dwi.bval", checkIfExists: true),
                     file("\${test_data_directory}/sub-01_dir-PA_dwi.bvec", checkIfExists: true),
                     file("\${test_data_directory}/sub-01_dir-PA_sbref.nii.gz", checkIfExists: true)]}
-                input[1] = []
+                input[1] = ''
                 """
             }
         }
@@ -76,7 +76,7 @@ nextflow_process {
                     [],
                     [],
                     file("\${test_data_directory}/sub-01_dir-PA_sbref.nii.gz", checkIfExists: true)]}
-                input[1] = []
+                input[1] = ''
                 """
             }
         }
@@ -112,7 +112,7 @@ nextflow_process {
                     file("\${test_data_directory}/sub-01_dir-PA_dwi.bval", checkIfExists: true),
                     file("\${test_data_directory}/sub-01_dir-PA_dwi.bvec", checkIfExists: true),
                     file("\${test_data_directory}/sub-01_dir-PA_sbref.nii.gz", checkIfExists: true)]}
-                input[1] = []
+                input[1] = ''
                 """
             }
         }

--- a/modules/nf-neuro/preproc/topup/tests/main.nf.test.snap
+++ b/modules/nf-neuro/preproc/topup/tests/main.nf.test.snap
@@ -47,36 +47,51 @@
     },
     "topup_light": {
         "content": [
-            "test__corrected_b0s.nii.gz",
+            "test1__corrected_b0s.nii.gz",
             "topup_results_fieldcoef.nii.gz",
             "topup_results_movpar.txt",
-            "test__rev_b0_warped.nii.gz",
+            "test1__rev_b0_warped.nii.gz",
             [
                 [
                     {
-                        "id": "test",
+                        "id": "test1",
                         "single_end": false
                     },
-                    "test__rev_b0_mean.nii.gz:md5,a0c63d7a8a234d85eeb63045ae2a8f60"
+                    "test1__rev_b0_mean.nii.gz:md5,a0c63d7a8a234d85eeb63045ae2a8f60"
+                ],
+                [
+                    {
+                        "id": "test2",
+                        "single_end": false
+                    },
+                    "test2__rev_b0_mean.nii.gz:md5,a0c63d7a8a234d85eeb63045ae2a8f60"
                 ]
             ],
             [
                 [
                     {
-                        "id": "test",
+                        "id": "test1",
                         "single_end": false
                     },
-                    "test__b0_mean.nii.gz:md5,91288914a80e7866ef8b08a363d617f9"
+                    "test1__b0_mean.nii.gz:md5,91288914a80e7866ef8b08a363d617f9"
+                ],
+                [
+                    {
+                        "id": "test2",
+                        "single_end": false
+                    },
+                    "test2__b0_mean.nii.gz:md5,91288914a80e7866ef8b08a363d617f9"
                 ]
             ],
             [
+                "versions.yml:md5,87d6001e63fd82f49d6dd80ed032d4c0",
                 "versions.yml:md5,87d6001e63fd82f49d6dd80ed032d4c0"
             ]
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
         },
-        "timestamp": "2024-11-01T16:21:36.189599346"
+        "timestamp": "2025-02-05T09:43:19.400777"
     }
 }


### PR DESCRIPTION
Setting the `val(config_topup)` as the input for the config file made `topup` run only once for all subjects. The test didn't catch this since we only tested with a single subject. Setting the input to `each config_topup` solves the issue.