### PR TITLE
Fix stub section of `registration/ants` + add stub-run test

### DIFF
--- a/modules/nf-neuro/registration/ants/main.nf
+++ b/modules/nf-neuro/registration/ants/main.nf
@@ -73,9 +73,6 @@ process REGISTRATION_ANTS {
     def prefix = task.ext.prefix ?: "${meta.id}"
 
     """
-    antsRegistrationSyNQuick.sh -h
-    antsApplyTransforms -h
-
     touch ${prefix}__t1_warped.nii.gz
     touch ${prefix}__output1GenericAffine.mat
     touch ${prefix}__output0InverseAffine.mat
@@ -86,5 +83,15 @@ process REGISTRATION_ANTS {
     "${task.process}":
         ants: \$(antsRegistration --version | grep "Version" | sed -E 's/.*v([0-9]+\\.[0-9]+\\.[0-9]+).*/\\1/')
     END_VERSIONS
+
+    function handle_code () {
+    local code=\$?
+    ignore=( 1 )
+    exit \$([[ " \${ignore[@]} " =~ " \$code " ]] && echo 0 || echo \$code)
+    }
+    trap 'handle_code' ERR
+
+    antsRegistrationSyNQuick.sh -h
+    antsApplyTransforms -h
     """
 }

--- a/modules/nf-neuro/registration/ants/tests/main.nf.test
+++ b/modules/nf-neuro/registration/ants/tests/main.nf.test
@@ -131,4 +131,40 @@ nextflow_process {
             )
         }
     }
+
+    test("registration - ants - stub") {
+        options "-stub-run"
+        when {
+            process {
+                """
+                ch_split_test_data = LOAD_DATA.out.test_data_directory
+                    .branch{
+                        T1w: it.simpleName == "T1w"
+                        b0: it.simpleName == "b0"
+                    }
+                ch_T1w = ch_split_test_data.T1w.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/T1w.nii.gz"),
+                        file("\${test_data_directory}/T1w_mask.nii.gz")
+                    ]
+                }
+                ch_b0 = ch_split_test_data.b0.map{
+                    test_data_directory -> [
+                        [ id:'test' ],
+                        file("\${test_data_directory}/b0.nii.gz")
+                    ]
+                }
+                input[0] = ch_b0
+                    .join(ch_T1w)
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.versions).match() }
+            )
+        }
+    }
 }

--- a/modules/nf-neuro/registration/ants/tests/main.nf.test.snap
+++ b/modules/nf-neuro/registration/ants/tests/main.nf.test.snap
@@ -269,5 +269,17 @@
             "nextflow": "24.10.2"
         },
         "timestamp": "2024-12-16T17:28:54.754431506"
+    },
+    "registration - ants - stub": {
+        "content": [
+            [
+                "versions.yml:md5,e1ac7994c0f0169d932e94c6e97a4894"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
+        },
+        "timestamp": "2025-02-03T14:45:05.628303"
     }
 }


### PR DESCRIPTION
The stub section of `registration/ants` was not updated to catch the exit code of the ants scripts (returning a non-zero exit code when calling the help)—I also added a test for a `-stub-run.` 