### PR TITLE
Subworkflow to transfer BIDS `.json` to `nextflow channels`

### DIFF
--- a/modules/nf-neuro/io/readbids/main.nf
+++ b/modules/nf-neuro/io/readbids/main.nf
@@ -6,7 +6,9 @@ process IO_READBIDS {
         'scilus/scilus:2.0.2' }"
 
     input:
-        tuple path(bids_folder), path(fs_folder), path(bids_ignore)
+        path(bids_folder)
+        path(fs_folder)
+        path(bids_ignore)
 
     output:
         path("tractoflow_bids_struct.json")             , emit: bidsstructure
@@ -17,9 +19,8 @@ process IO_READBIDS {
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
-    def fs_folder = fs_folder ? "--fs $fs_folder" : ''
-    def bids_ignore = bids_ignore ? "--bids_ignore $bids_ignore" : ''
+    fs_folder = fs_folder ? "--fs $fs_folder" : ''
+    bids_ignore = bids_ignore ? "--bids_ignore $bids_ignore" : ''
     def readout = task.ext.readout ? "--readout " + task.ext.readout : ''
     def clean_flag = task.ext.clean_bids ? "--clean " : ''
 
@@ -39,7 +40,6 @@ process IO_READBIDS {
 
 
     stub:
-    def args = task.ext.args ?: ''
     """
     scil_bids_validate.py -h
 

--- a/modules/nf-neuro/io/readbids/main.nf
+++ b/modules/nf-neuro/io/readbids/main.nf
@@ -21,7 +21,7 @@ process IO_READBIDS {
     script:
     fs_folder = fs_folder ? "--fs $fs_folder" : ''
     bids_ignore = bids_ignore ? "--bids_ignore $bids_ignore" : ''
-    def readout = task.ext.readout ? "--readout " + task.ext.readout : ''
+    def readout = task.ext.readout ? "--readout " + task.ext.readout : "--readout 0.062"
     def clean_flag = task.ext.clean_bids ? "--clean " : ''
 
     """

--- a/modules/nf-neuro/io/readbids/meta.yml
+++ b/modules/nf-neuro/io/readbids/meta.yml
@@ -30,7 +30,7 @@ args:
   - readout:
       type: float
       description: Readout time to add in metadata.
-      default: null
+      default: 0.062
   - clean_bids:
       type: boolean
       description: |

--- a/modules/nf-neuro/io/readbids/meta.yml
+++ b/modules/nf-neuro/io/readbids/meta.yml
@@ -26,6 +26,18 @@ input:
       description: bids_ignore file
       pattern: "*.{bids_ignore}"
 
+args:
+  - readout:
+      type: float
+      description: Readout time to add in metadata.
+      default: null
+  - clean_bids:
+      type: boolean
+      description: |
+        If set to true, will remove participants with missing files
+        from the final BIDS layout.
+      default: false
+
 output:
   - versions:
       type: file

--- a/modules/nf-neuro/io/readbids/tests/main.nf.test
+++ b/modules/nf-neuro/io/readbids/tests/main.nf.test
@@ -31,11 +31,11 @@ nextflow_process {
                 """
                 input[0] = LOAD_DATA.out.test_data_directory.map{
                     test_data_directory -> [
-                        file("\${test_data_directory}/i_bids", checkIfExists: true),
-                        [],
-                        [],
+                        file("\${test_data_directory}/i_bids", checkIfExists: true)
                     ]
                 }
+                input[1] = []
+                input[2] = []
                 """
             }
         }
@@ -46,7 +46,5 @@ nextflow_process {
                 { assert snapshot(process.out).match() }
             )
         }
-
     }
-
 }

--- a/subworkflows/nf-neuro/io_bids/main.nf
+++ b/subworkflows/nf-neuro/io_bids/main.nf
@@ -5,11 +5,19 @@ workflow IO_BIDS {
     take:
     bids_folder         // channel: [ path(bids_folder) ]
     fs_folder           // channel: [ path(fs_folder) ]
-    bidsignore         // channel: [ path(bids_ignore) ]
+    bidsignore          // channel: [ path(bids_ignore) ]
 
     main:
 
     ch_versions = Channel.empty()
+
+    // ** Sanity check to ensure channels are single-item ** //
+    BIDS_FOLDER_SANITY_CHECK = bids_folder.collect().map { folders ->
+        if (folders.size() > 1) {
+            error "ERROR: You must supply only a single BIDS folder."
+        }
+        return folders[0]
+    }
 
     // ** Fetching the BIDS data as a json file ** //
     IO_READBIDS (

--- a/subworkflows/nf-neuro/io_bids/main.nf
+++ b/subworkflows/nf-neuro/io_bids/main.nf
@@ -23,7 +23,7 @@ workflow IO_BIDS {
     ch_files = IO_READBIDS.out.bidsstructure
         .flatMap{ layout ->
             def json = new groovy.json.JsonSlurper().parseText(layout.getText())
-            json.collect { item ->
+            return json.collect { item ->
                 // ** Collecting the subject's ID ** //
                 def sid = "sub-" + item.subject
 
@@ -34,9 +34,9 @@ workflow IO_BIDS {
                 def run = item.run ? "run-" + item.run : ""
 
                 // ** Collecting TotalReadoutTime, PhaseEncodingDirection ** //
-                def tr = item.TotalReadoutTime ?: ""
-                def phase = item.DWIPhaseEncodingDirection ?: ""
-                def revphase = item.rev_DWIPhaseEncodingDirection ?: ""
+                def dwi_tr = item.TotalReadoutTime ?: ""
+                def dwi_phase = item.DWIPhaseEncodingDirection ?: ""
+                def dwi_revphase = item.rev_DWIPhaseEncodingDirection ?: ""
 
                 // ** Validating there is not missing data ** //
                 item.each { _key, value ->
@@ -52,7 +52,8 @@ workflow IO_BIDS {
 
                 // ** Collecting the files ** //
                 return [
-                    [id: sid, session: ses, run: run, tr: tr, phase: phase, revphase: revphase],
+                    [id: sid, session: ses, run: run, dwi_tr: dwi_tr,
+                    dwi_phase: dwi_phase, dwi_revphase: dwi_revphase],
                     item.t1 ? file(item.t1) : [],
                     item.wmparc ? file(item.wmparc) : [],
                     item.aparc_aseg ? file(item.aparc_aseg) : [],

--- a/subworkflows/nf-neuro/io_bids/main.nf
+++ b/subworkflows/nf-neuro/io_bids/main.nf
@@ -12,11 +12,10 @@ workflow IO_BIDS {
     ch_versions = Channel.empty()
 
     // ** Sanity check to ensure channels are single-item ** //
-    BIDS_FOLDER_SANITY_CHECK = bids_folder.collect().map { folders ->
+    bids_folder.collect().map { folders ->
         if (folders.size() > 1) {
             error "ERROR: You must supply only a single BIDS folder."
         }
-        return folders[0]
     }
 
     // ** Fetching the BIDS data as a json file ** //

--- a/subworkflows/nf-neuro/io_bids/main.nf
+++ b/subworkflows/nf-neuro/io_bids/main.nf
@@ -1,0 +1,88 @@
+include { IO_READBIDS   } from '../../../modules/nf-neuro/io/readbids/main.nf'
+
+workflow IO_BIDS {
+
+    take:
+    bids_folder         // channel: [ path(bids_folder) ]
+    fs_folder           // channel: [ path(fs_folder) ]
+    bidsignore         // channel: [ path(bids_ignore) ]
+
+    main:
+
+    ch_versions = Channel.empty()
+
+    // ** Fetching the BIDS data as a json file ** //
+    IO_READBIDS (
+        bids_folder,
+        fs_folder,
+        bidsignore
+    )
+    ch_versions = ch_versions.mix(IO_READBIDS.out.versions)
+
+    // ** Converting the json file into channels. ** //
+    ch_files = IO_READBIDS.out.bidsstructure
+        .flatMap{ layout ->
+            def json = new groovy.json.JsonSlurper().parseText(layout.getText())
+            json.collect { item ->
+                // ** Collecting the subject's ID ** //
+                def sid = "sub-" + item.subject
+
+                // ** Collecting the session's ID if present ** //
+                def ses = item.session ? "_ses-" + item.session : ""
+
+                // ** Collecting the run's ID if present ** //
+                def run = item.run ? "run-" + item.run : ""
+
+                // ** Collecting TotalReadoutTime, PhaseEncodingDirection ** //
+                def tr = item.TotalReadoutTime ?: ""
+                def phase = item.DWIPhaseEncodingDirection ?: ""
+                def revphase = item.rev_DWIPhaseEncodingDirection ?: ""
+
+                // ** Validating there is not missing data ** //
+                item.each { _key, value ->
+                    if (value == "todo") {
+                        error   "ERROR ~ $sid contains missing files, please" +
+                                "check the BIDS layout. You can validate your" +
+                                "structure using the bids-validator tool:" +
+                                "https://bids-standard.github.io/bids-validator/" +
+                                "or the docker version: " +
+                                "https://hub.docker.com/r/bids/validator"
+                    }
+                }
+
+                // ** Collecting the files ** //
+                return [
+                    [id: sid, session: ses, run: run, tr: tr, phase: phase, revphase: revphase],
+                    item.t1 ? file(item.t1) : [],
+                    item.wmparc ? file(item.wmparc) : [],
+                    item.aparc_aseg ? file(item.aparc_aseg) : [],
+                    item.dwi ? file(item.dwi) : [],
+                    item.bval ? file(item.bval) : [],
+                    item.bvec ? file(item.bvec) : [],
+                    item.rev_dwi ? file(item.rev_dwi) : [],
+                    item.rev_bval ? file(item.rev_bval) : [],
+                    item.rev_bvec ? file(item.rev_bvec) : [],
+                    item.rev_topup ? file(item.rev_topup) : [],
+                ]
+            }
+        }
+        .multiMap{ meta, t1, wmparc, aparc_aseg, dwi, bval, bvec, rev_dwi, rev_bval, rev_bvec, rev_b0 ->
+                t1: [meta, t1]
+                wmparc: [meta, wmparc]
+                aparc_aseg: [meta, aparc_aseg]
+                dwi_bval_bvec: [meta, dwi, bval, bvec]
+                rev_dwi_bval_bvec: [meta, rev_dwi, rev_bval, rev_bvec]
+                rev_b0: [meta, rev_b0]
+        }
+
+    emit:
+    ch_t1                   = ch_files.t1                   // channel: [ [meta], file(t1) ]
+    ch_wmparc               = ch_files.wmparc               // channel: [ [meta], file(wmparc) ]
+    ch_aparc_aseg           = ch_files.aparc_aseg           // channel: [ [meta], file(aparc_aseg) ]
+    ch_dwi_bval_bvec        = ch_files.dwi_bval_bvec        // channel: [ [meta], file(dwi), file(bval), file(bvec) ]
+    ch_rev_dwi_bval_bvec    = ch_files.rev_dwi_bval_bvec    // channel: [ [meta], file(rev_dwi), file(rev_bval), file(rev_bvec) ]
+    ch_rev_b0               = ch_files.rev_b0               // channel: [ [meta], file(fieldmap) ]
+
+    versions = ch_versions                     // channel: [ versions.yml ]
+}
+

--- a/subworkflows/nf-neuro/io_bids/meta.yml
+++ b/subworkflows/nf-neuro/io_bids/meta.yml
@@ -1,0 +1,100 @@
+name: "io_bids"
+description: |
+  Subworkflow loading files from a BIDS directory. It is used in conjunction
+  with the IO_READBIDS module which uses the scilpy CLI script to parse the
+  BIDS directory and fetch the metadata.
+  ------------- Current supported files/metadata -------------
+  Files:
+    - T1w
+    - White matter parcellation from FreeSurfer.
+    - Grey matter parcellation from FreeSurfer.
+    - Diffusion weighted images (dwi)
+    - B-values (bval)
+    - B-vectors (bvec)
+    - Reverse encoded diffusion weighted images (rev_dwi)
+    - B-values for the rev_dwi (rev_bval)
+    - B-vectors for the rev_dwi (rev_bvec)
+    - Reverse b0 image (rev_b0)
+  Metadata (within the meta):
+    - Subject ID
+    - Session ID
+    - Run ID
+    - DWI Phase Encoding Direction
+    - DWI Total Readout Time
+    - Reverse DWI Phase Encoding Direction
+
+  **Note**: This subworkflow is meant to be an example of how to use the
+  IO_READBIDS module. It can be modified to fit the user's needs.
+
+keywords:
+  - IO
+  - BIDS
+  - Files
+
+components:
+  - io/readbids
+
+input:
+  - bids_folder:
+      type: directory
+      description: |
+        Path to the BIDS directory.
+        Structure: [ path(bids_folder) ]
+  - fs_folder:
+      type: directory
+      description: |
+        Path to the FreeSurfer directory.
+        Structure: [ path(fs_folder) ]
+  - bidsignore:
+      type: file
+      description: |
+        Path to the .bidsignore file.
+        Structure: [ path(bidsignore) ]
+
+output:
+  - ch_t1:
+      type: file
+      description: |
+        Channel containing all T1w files
+        Structure: [ val(meta), path(t1) ]
+      pattern: "*.nii.gz"
+  - ch_wmparc:
+      type: file
+      description: |
+        Channel containing all FreeSurfer white matter parcellation files.
+        Structure: [ val(meta), path(wmparc) ]
+      pattern: "*.mgz"
+  - ch_aparc_aseg:
+      type: file
+      description: |
+        Channel containing all FreeSurfer grey matter parcellation files.
+        Structure: [ val(meta), path(aparc_aseg) ]
+      pattern: "*.mgz"
+  - ch_dwi_bval_bvec:
+      type: file
+      description: |
+        Channel containing all diffusion weighted images, b-values and b-vectors.
+        Structure: [ val(meta), path(dwi), path(bval), path(bvec) ]
+      pattern: "*.{nii.gz,bval,bvec}"
+  - ch_rev_dwi_bval_bvec:
+      type: file
+      description: |
+        Channel containing all reverse encoded diffusion weighted images, b-values and b-vectors.
+        Structure: [ val(meta), path(rev_dwi), path(rev_bval), path(rev_bvec) ]
+      pattern: "*.{nii.gz,bval,bvec}"
+  - ch_rev_b0:
+      type: file
+      description: |
+        Channel containing all reverse b0 images.
+        Structure: [ val(meta), path(rev_b0) ]
+      pattern: "*.nii.gz"
+  - versions:
+      type: file
+      description: |
+        File containing software versions
+        Structure: [ path(versions.yml) ]
+      pattern: "versions.yml"
+authors:
+  - "@gagnonanthony"
+maintainers:
+  - "@gagnonanthony"

--- a/subworkflows/nf-neuro/io_bids/meta.yml
+++ b/subworkflows/nf-neuro/io_bids/meta.yml
@@ -24,7 +24,8 @@ description: |
     - Reverse DWI Phase Encoding Direction (dwi_revphase)
 
   **Note**: This subworkflow is meant to be an example of how to use the
-  IO_READBIDS module. It can be modified to fit the user's needs.
+  IO_READBIDS module. It only supports a single BIDS folder as an input.
+  It can be modified to fit the user's needs.
 
 keywords:
   - IO
@@ -38,7 +39,7 @@ input:
   - bids_folder:
       type: directory
       description: |
-        Path to the BIDS directory.
+        Path to the BIDS directory. (You must supply only a single BIDS directory)
         Structure: [ path(bids_folder) ]
   - fs_folder:
       type: directory

--- a/subworkflows/nf-neuro/io_bids/meta.yml
+++ b/subworkflows/nf-neuro/io_bids/meta.yml
@@ -16,12 +16,12 @@ description: |
     - B-vectors for the rev_dwi (rev_bvec)
     - Reverse b0 image (rev_b0)
   Metadata (within the meta):
-    - Subject ID
-    - Session ID
-    - Run ID
-    - DWI Phase Encoding Direction
-    - DWI Total Readout Time
-    - Reverse DWI Phase Encoding Direction
+    - Subject ID (id)
+    - Session ID (ses)
+    - Run ID (run)
+    - DWI Total Readout Time (dwi_tr)
+    - DWI Phase Encoding Direction (dwi_phase)
+    - Reverse DWI Phase Encoding Direction (dwi_revphase)
 
   **Note**: This subworkflow is meant to be an example of how to use the
   IO_READBIDS module. It can be modified to fit the user's needs.

--- a/subworkflows/nf-neuro/io_bids/tests/main.nf.test
+++ b/subworkflows/nf-neuro/io_bids/tests/main.nf.test
@@ -1,0 +1,78 @@
+nextflow_workflow {
+
+    name "Test Subworkflow IO_BIDS"
+    script "../main.nf"
+    workflow "IO_BIDS"
+
+    tag "subworkflows"
+    tag "subworkflows_nfcore"
+    tag "subworkflows/io_bids"
+    tag "subworkflows/load_test_data"
+
+    tag "io"
+    tag "io/readbids"
+
+    setup {
+        run("LOAD_TEST_DATA", alias: "LOAD_DATA") {
+            script "../../load_test_data/main.nf"
+            process {
+                """
+                input[0] = Channel.from( [ "bids.zip" ] )
+                input[1] = "test.load-test-data"
+                """
+            }
+        }
+    }
+
+    test("Read BIDS directory - without .bidsignore") {
+
+        when {
+            workflow {
+                """
+                input[0] = LOAD_DATA.out.test_data_directory.map{
+                    test_data_directory -> [
+                        file("\${test_data_directory}/i_bids/")
+                    ]
+                }
+                input[1] = Channel.from( [] )
+                input[2] = Channel.from( [] )
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(workflow.out).match()}
+            )
+        }
+    }
+
+    test("Read BIDS directory - with .bidsignore") {
+
+        when {
+            workflow {
+                """
+                input[0] = LOAD_DATA.out.test_data_directory.map{
+                    test_data_directory -> [
+                        file("\${test_data_directory}/i_bids/")
+                    ]
+                }
+                input[1] = Channel.from( [] )
+                input[2] = LOAD_DATA.out.test_data_directory.map{
+                    test_data_directory -> [
+                        file("\${test_data_directory}/i_bids/.bidsignore")
+                    ]
+                }
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(workflow.out).match()}
+            )
+        }
+    }
+}

--- a/subworkflows/nf-neuro/io_bids/tests/main.nf.test
+++ b/subworkflows/nf-neuro/io_bids/tests/main.nf.test
@@ -4,13 +4,16 @@ nextflow_workflow {
     script "../main.nf"
     workflow "IO_BIDS"
 
+    config "./nextflow.config"
+
     tag "subworkflows"
     tag "subworkflows_nfcore"
     tag "subworkflows/io_bids"
-    tag "subworkflows/load_test_data"
 
     tag "io"
     tag "io/readbids"
+
+    tag "load_test_data"
 
     setup {
         run("LOAD_TEST_DATA", alias: "LOAD_DATA") {
@@ -31,11 +34,11 @@ nextflow_workflow {
                 """
                 input[0] = LOAD_DATA.out.test_data_directory.map{
                     test_data_directory -> [
-                        file("\${test_data_directory}/i_bids/")
+                        file("\${test_data_directory}/i_bids", checkIfExists: true)
                     ]
                 }
-                input[1] = Channel.from( [] )
-                input[2] = Channel.from( [] )
+                input[1] = []
+                input[2] = []
                 """
             }
         }
@@ -55,10 +58,10 @@ nextflow_workflow {
                 """
                 input[0] = LOAD_DATA.out.test_data_directory.map{
                     test_data_directory -> [
-                        file("\${test_data_directory}/i_bids/")
+                        file("\${test_data_directory}/i_bids", checkIfExists: true)
                     ]
                 }
-                input[1] = Channel.from( [] )
+                input[1] = []
                 input[2] = LOAD_DATA.out.test_data_directory.map{
                     test_data_directory -> [
                         file("\${test_data_directory}/i_bids/.bidsignore")

--- a/subworkflows/nf-neuro/io_bids/tests/main.nf.test
+++ b/subworkflows/nf-neuro/io_bids/tests/main.nf.test
@@ -37,16 +37,16 @@ nextflow_workflow {
                         file("\${test_data_directory}/i_bids", checkIfExists: true)
                     ]
                 }
-                input[1] = []
-                input[2] = []
+                input[1] = Channel.empty()
+                input[2] = Channel.empty()
                 """
             }
         }
 
         then {
             assertAll(
-                { assert workflow.success},
-                { assert snapshot(workflow.out).match()}
+                { assert workflow.success },
+                { assert snapshot(workflow.out).match() }
             )
         }
     }
@@ -61,7 +61,7 @@ nextflow_workflow {
                         file("\${test_data_directory}/i_bids", checkIfExists: true)
                     ]
                 }
-                input[1] = []
+                input[1] = Channel.empty()
                 input[2] = LOAD_DATA.out.test_data_directory.map{
                     test_data_directory -> [
                         file("\${test_data_directory}/i_bids/.bidsignore")
@@ -73,8 +73,33 @@ nextflow_workflow {
 
         then {
             assertAll(
-                { assert workflow.success},
-                { assert snapshot(workflow.out).match()}
+                { assert workflow.success },
+                { assert snapshot(workflow.out).match() }
+            )
+        }
+    }
+
+    test("Read BIDS directory - with 2 folder - invalid") {
+
+        when {
+            workflow {
+                """
+                input[0] = LOAD_DATA.out.test_data_directory.map{
+                    test_data_directory -> [
+                        file("\${test_data_directory}/i_bids", checkIfExists: true),
+                        file("\${test_data_directory}/i_bids", checkIfExists: true)
+                    ]
+                }
+                input[1] = Channel.empty()
+                input[2] = Channel.empty()
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.failed },
+                { assert workflow.stdout.contains("ERROR: You must supply only a single BIDS folder.") }
             )
         }
     }

--- a/subworkflows/nf-neuro/io_bids/tests/main.nf.test.snap
+++ b/subworkflows/nf-neuro/io_bids/tests/main.nf.test.snap
@@ -1,0 +1,108 @@
+{
+    "Read BIDS directory - with .bidsignore": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    
+                ],
+                "ch_aparc_aseg": [
+                    
+                ],
+                "ch_dwi_bval_bvec": [
+                    
+                ],
+                "ch_rev_b0": [
+                    
+                ],
+                "ch_rev_dwi_bval_bvec": [
+                    
+                ],
+                "ch_t1": [
+                    
+                ],
+                "ch_wmparc": [
+                    
+                ],
+                "versions": [
+                    
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
+        },
+        "timestamp": "2025-02-05T21:37:09.32917"
+    },
+    "Read BIDS directory - without .bidsignore": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    
+                ],
+                "ch_aparc_aseg": [
+                    
+                ],
+                "ch_dwi_bval_bvec": [
+                    
+                ],
+                "ch_rev_b0": [
+                    
+                ],
+                "ch_rev_dwi_bval_bvec": [
+                    
+                ],
+                "ch_t1": [
+                    
+                ],
+                "ch_wmparc": [
+                    
+                ],
+                "versions": [
+                    
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
+        },
+        "timestamp": "2025-02-05T21:37:06.012742"
+    }
+}

--- a/subworkflows/nf-neuro/io_bids/tests/main.nf.test.snap
+++ b/subworkflows/nf-neuro/io_bids/tests/main.nf.test.snap
@@ -21,7 +21,7 @@
                     
                 ],
                 "6": [
-                    
+                    "versions.yml:md5,79bfad0b798f5c3c726399a83ccd07cb"
                 ],
                 "ch_aparc_aseg": [
                     
@@ -42,7 +42,7 @@
                     
                 ],
                 "versions": [
-                    
+                    "versions.yml:md5,79bfad0b798f5c3c726399a83ccd07cb"
                 ]
             }
         ],
@@ -50,7 +50,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.3"
         },
-        "timestamp": "2025-02-05T21:37:09.32917"
+        "timestamp": "2025-02-05T22:11:04.178305"
     },
     "Read BIDS directory - without .bidsignore": {
         "content": [
@@ -74,7 +74,7 @@
                     
                 ],
                 "6": [
-                    
+                    "versions.yml:md5,79bfad0b798f5c3c726399a83ccd07cb"
                 ],
                 "ch_aparc_aseg": [
                     
@@ -95,7 +95,7 @@
                     
                 ],
                 "versions": [
-                    
+                    "versions.yml:md5,79bfad0b798f5c3c726399a83ccd07cb"
                 ]
             }
         ],
@@ -103,6 +103,6 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.3"
         },
-        "timestamp": "2025-02-05T21:37:06.012742"
+        "timestamp": "2025-02-05T22:10:54.349853"
     }
 }

--- a/subworkflows/nf-neuro/io_bids/tests/main.nf.test.snap
+++ b/subworkflows/nf-neuro/io_bids/tests/main.nf.test.snap
@@ -21,7 +21,7 @@
                     
                 ],
                 "6": [
-                    "versions.yml:md5,79bfad0b798f5c3c726399a83ccd07cb"
+                    
                 ],
                 "ch_aparc_aseg": [
                     
@@ -42,7 +42,7 @@
                     
                 ],
                 "versions": [
-                    "versions.yml:md5,79bfad0b798f5c3c726399a83ccd07cb"
+                    
                 ]
             }
         ],
@@ -50,7 +50,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.3"
         },
-        "timestamp": "2025-02-05T22:11:04.178305"
+        "timestamp": "2025-02-14T08:08:38.357417"
     },
     "Read BIDS directory - without .bidsignore": {
         "content": [
@@ -74,7 +74,7 @@
                     
                 ],
                 "6": [
-                    "versions.yml:md5,79bfad0b798f5c3c726399a83ccd07cb"
+                    
                 ],
                 "ch_aparc_aseg": [
                     
@@ -95,7 +95,7 @@
                     
                 ],
                 "versions": [
-                    "versions.yml:md5,79bfad0b798f5c3c726399a83ccd07cb"
+                    
                 ]
             }
         ],
@@ -103,6 +103,6 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.3"
         },
-        "timestamp": "2025-02-05T22:10:54.349853"
+        "timestamp": "2025-02-14T08:08:01.011554"
     }
 }

--- a/subworkflows/nf-neuro/io_bids/tests/nextflow.config
+++ b/subworkflows/nf-neuro/io_bids/tests/nextflow.config
@@ -1,0 +1,7 @@
+process {
+    withName: "IO_READBIDS" {
+        publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+        ext.readout = 0.062
+        ext.clean_bids = true
+    }
+}

--- a/subworkflows/nf-neuro/io_bids/tests/tags.yml
+++ b/subworkflows/nf-neuro/io_bids/tests/tags.yml
@@ -1,0 +1,2 @@
+subworkflows/io_bids:
+  - subworkflows/nf-neuro/io_bids/**


### PR DESCRIPTION
New subworkflow to cover the gap between the `json` file outputted by `IO_READBIDS` and usable `nextflow channels`. It uses all currently collected files from `scil_bids_validate.py`, but should be adapted in future pipelines to meet the specific file requirements.

**Tests are not super informative since there aren't actual files in the test data.**