### PR TITLE
[HOTFIX] Don't detect changes when base commit undefined

### DIFF
--- a/.github/workflows/run_checks_suite.yml
+++ b/.github/workflows/run_checks_suite.yml
@@ -83,6 +83,7 @@ jobs:
   nf-test-changes:
     name: compute - changes
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
     outputs:
       paths: ${{ steps.changes.outputs.components }}
       modules: ${{ steps.components.outputs.modules }}


### PR DESCRIPTION
…to-date commit)

## Bug category

- [ ] Critical (some functionalities is not working at all)
- [x] Major (something is not working as expected)
- [ ] Minor (something but could be improved)
- [ ] Trivial (documentation needs correcting and other non-functional issues)

## Describe the bug

Running the `update_main` github workflow fails if done manually, since **head ref** and **base ref** are the same.

## Steps to reproduce the bug

Launch the `update_main` workflow by hand, it'll fail.
