### PR TITLE
Add channel to collect multiqc files in `preproc_dwi` and `topup_eddy`

### DIFF
--- a/subworkflows/nf-neuro/preproc_dwi/main.nf
+++ b/subworkflows/nf-neuro/preproc_dwi/main.nf
@@ -25,6 +25,7 @@ workflow PREPROC_DWI {
     main:
 
         ch_versions = Channel.empty()
+        ch_multiqc_files = Channel.empty()
 
         // ** Denoise DWI ** //
         if (params.preproc_dwi_run_denoising) {
@@ -101,6 +102,7 @@ workflow PREPROC_DWI {
         // ** Eddy Topup ** //
         TOPUP_EDDY ( ch_dwi, ch_b0, ch_rev_dwi, ch_rev_b0, ch_config_topup )
         ch_versions = ch_versions.mix(TOPUP_EDDY.out.versions.first())
+        ch_multiqc_files = ch_multiqc_files.mix(TOPUP_EDDY.out.mqc)
 
         // ** Bet-crop DWI ** //
         ch_betcrop_dwi = TOPUP_EDDY.out.dwi
@@ -177,5 +179,6 @@ workflow PREPROC_DWI {
         dwi_bounding_box    = BETCROP_FSLBETCROP.out.bbox   // channel: [ val(meta), dwi-bounding-box ]
         dwi_topup_eddy      = TOPUP_EDDY.out.dwi            // channel: [ val(meta), dwi-after-topup-eddy ]
         dwi_n4              = ch_dwi_n4                     // channel: [ val(meta), dwi-after-n4 ]
+        mqc                 = ch_multiqc_files              // channel: [ val(meta), mqc ]
         versions            = ch_versions                   // channel: [ versions.yml ]
 }

--- a/subworkflows/nf-neuro/preproc_dwi/meta.yml
+++ b/subworkflows/nf-neuro/preproc_dwi/meta.yml
@@ -134,6 +134,12 @@ output:
         Channel containing DWI after denoised, corrected for susceptibility and/or eddy currents and motion, cropped and normalized (N4).
         Structure: [ val(meta), path(dwi) ]
       pattern: "*_normalized.{nii,nii.gz}"
+  - mqc:
+      type: file
+      description: |
+        Channel containing the quality control images for MultiQC.
+        Structure: [ val(meta), path(mqc) ]
+      pattern: "*_mqc.{gif,png}"
   - versions:
       type: file
       description: |

--- a/subworkflows/nf-neuro/preproc_dwi/tests/main.nf.test.snap
+++ b/subworkflows/nf-neuro/preproc_dwi/tests/main.nf.test.snap
@@ -12,7 +12,6 @@
             ],
             [
                 "versions.yml:md5,0280006ceecc575513278292734ffb27",
-                "versions.yml:md5,0494fbf74bc9c16d2b30cb45b3bba66b",
                 "versions.yml:md5,0b8c908e52917b0b706fc9d1b4d6cd24",
                 "versions.yml:md5,10ec368dc91791041043fddf6ea3d5c9",
                 "versions.yml:md5,4d9548c7486e8dbb65af71f143ed331c",
@@ -20,6 +19,7 @@
                 "versions.yml:md5,662ea558da42564a0f6140473132bcb4",
                 "versions.yml:md5,7ddf2e98f59b19c9b933670550f26ad7",
                 "versions.yml:md5,9ed0cfbbfa39c46a53dbe911a68cbc88",
+                "versions.yml:md5,be7d5bfaf3bf493f62efa98e274cc01d",
                 "versions.yml:md5,c15ba5efd24564dba4710b6da8c4b791",
                 "versions.yml:md5,ea5858879452a59bb355228ae7f38111",
                 "versions.yml:md5,f041502e22449973d84ac1c618e8ebf9"
@@ -33,10 +33,10 @@
             "test__dwi_corrected.nii.gz"
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.10.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
         },
-        "timestamp": "2025-02-05T15:39:49.311209011"
+        "timestamp": "2025-02-28T08:50:35.321464"
     },
     "preproc_dwi_rev_b0": {
         "content": [
@@ -51,12 +51,12 @@
             ],
             [
                 "versions.yml:md5,0280006ceecc575513278292734ffb27",
-                "versions.yml:md5,0494fbf74bc9c16d2b30cb45b3bba66b",
                 "versions.yml:md5,0b8c908e52917b0b706fc9d1b4d6cd24",
                 "versions.yml:md5,10ec368dc91791041043fddf6ea3d5c9",
                 "versions.yml:md5,571265e710ca29198e69be22c0f970d5",
                 "versions.yml:md5,7ddf2e98f59b19c9b933670550f26ad7",
                 "versions.yml:md5,9ed0cfbbfa39c46a53dbe911a68cbc88",
+                "versions.yml:md5,be7d5bfaf3bf493f62efa98e274cc01d",
                 "versions.yml:md5,c15ba5efd24564dba4710b6da8c4b791",
                 "versions.yml:md5,ea5858879452a59bb355228ae7f38111",
                 "versions.yml:md5,f041502e22449973d84ac1c618e8ebf9"
@@ -70,10 +70,10 @@
             "test__dwi_corrected.nii.gz"
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.10.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
         },
-        "timestamp": "2025-02-05T15:35:06.695089436"
+        "timestamp": "2025-02-28T08:47:25.557731"
     },
     "preproc_dwi_all_options": {
         "content": [
@@ -88,7 +88,6 @@
             ],
             [
                 "versions.yml:md5,0280006ceecc575513278292734ffb27",
-                "versions.yml:md5,0494fbf74bc9c16d2b30cb45b3bba66b",
                 "versions.yml:md5,0b8c908e52917b0b706fc9d1b4d6cd24",
                 "versions.yml:md5,10ec368dc91791041043fddf6ea3d5c9",
                 "versions.yml:md5,4d9548c7486e8dbb65af71f143ed331c",
@@ -96,6 +95,7 @@
                 "versions.yml:md5,662ea558da42564a0f6140473132bcb4",
                 "versions.yml:md5,7ddf2e98f59b19c9b933670550f26ad7",
                 "versions.yml:md5,9ed0cfbbfa39c46a53dbe911a68cbc88",
+                "versions.yml:md5,be7d5bfaf3bf493f62efa98e274cc01d",
                 "versions.yml:md5,c15ba5efd24564dba4710b6da8c4b791",
                 "versions.yml:md5,ea5858879452a59bb355228ae7f38111",
                 "versions.yml:md5,f041502e22449973d84ac1c618e8ebf9"
@@ -109,9 +109,9 @@
             "test__dwi_corrected.nii.gz"
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.10.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
         },
-        "timestamp": "2025-02-05T15:43:09.050637899"
+        "timestamp": "2025-02-28T08:53:44.242823"
     }
 }

--- a/subworkflows/nf-neuro/topup_eddy/main.nf
+++ b/subworkflows/nf-neuro/topup_eddy/main.nf
@@ -18,6 +18,7 @@ workflow TOPUP_EDDY {
 
     main:
         ch_versions = Channel.empty()
+        ch_multiqc_files = Channel.empty()
 
         ch_topup_fieldcoeff = Channel.empty()
         ch_topup_movpart = Channel.empty()
@@ -46,6 +47,7 @@ workflow TOPUP_EDDY {
             // ** RUN TOPUP ** //
             PREPROC_TOPUP ( ch_topup, ch_config_topup )
             ch_versions = ch_versions.mix(PREPROC_TOPUP.out.versions.first())
+            ch_multiqc_files = ch_multiqc_files.mix(PREPROC_TOPUP.out.mqc)
 
             ch_topup_fieldcoeff = PREPROC_TOPUP.out.topup_fieldcoef
             ch_topup_movpart = PREPROC_TOPUP.out.topup_movpart
@@ -78,6 +80,8 @@ workflow TOPUP_EDDY {
             // ** RUN EDDY **//
             PREPROC_EDDY ( ch_eddy_input )
             ch_versions = ch_versions.mix(PREPROC_EDDY.out.versions.first())
+            ch_multiqc_files = ch_multiqc_files.mix(PREPROC_EDDY.out.dwi_eddy_mqc)
+            ch_multiqc_files = ch_multiqc_files.mix(PREPROC_EDDY.out.rev_dwi_eddy_mqc)
 
             ch_dwi_extract_b0 = PREPROC_EDDY.out.dwi_corrected
                 .join(PREPROC_EDDY.out.bval_corrected)
@@ -113,5 +117,6 @@ workflow TOPUP_EDDY {
         bvec     = ch_output_dwi.bvec   // channel: [ val(meta), bvec-corrected ]
         b0       = ch_b0_corrected      // channel: [ val(meta), b0-corrected ]
         b0_mask  = ch_b0_mask           // channel: [ val(meta), b0-mask ]
+        mqc      = ch_multiqc_files     // channel: [ val(meta), mqc ]
         versions = ch_versions          // channel: [ versions.yml ]
 }

--- a/subworkflows/nf-neuro/topup_eddy/meta.yml
+++ b/subworkflows/nf-neuro/topup_eddy/meta.yml
@@ -106,6 +106,13 @@ output:
       description: Nifti volume - Mask for b0 corrected
       pattern: "*__b0_bet_mask.nii.gz"
 
+  - mqc:
+      type: file
+      description: |
+        Channel containing the quality control images for MultiQC.
+        Structure: [ val(meta), path(mqc) ]
+      pattern: "*_mqc.{gif,png}"
+
   - versions:
       type: file
       description: File containing software versions

--- a/subworkflows/nf-neuro/tractoflow/tests/main.nf.test.snap
+++ b/subworkflows/nf-neuro/tractoflow/tests/main.nf.test.snap
@@ -3,7 +3,7 @@
         "content": [
             "test_dwi_resampled.nii.gz",
             "test__dwi_eddy_corrected.bval:md5,7995daabbd74fcf7c365a39a779f67e9",
-            "test__dwi_eddy_corrected.bvec:md5,b3d6f6e2ec5c7cecad2207e5ea53fd79",
+            "test__dwi_eddy_corrected.bvec:md5,dbc6f91d13b50966037ef218bdfdaacf",
             "test__t1_warped.nii.gz",
             "test__mask_wm.nii.gz",
             "test__mask_gm.nii.gz",
@@ -55,16 +55,16 @@
                 "versions.yml:md5,4a7c801d46bade11523003b6bd06f8ed",
                 "versions.yml:md5,647b63809e635c82552cf53178bf73be",
                 "versions.yml:md5,9e058d5e2eaf4cf239570ca80d20207f",
+                "versions.yml:md5,9ec2ceb761ab4faf9c19e46d7aa201c9",
                 "versions.yml:md5,aaab00d1fa7d070cc7ee67fd768416b8",
                 "versions.yml:md5,da10c87dbb2ad07aa8bbf89a0c172a60",
-                "versions.yml:md5,e092829f98d53bda1802d1cda0cb017f",
-                "versions.yml:md5,fc6a2d3923b6ecd60b833ce5f09f8877"
+                "versions.yml:md5,e092829f98d53bda1802d1cda0cb017f"
             ]
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.10.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
         },
-        "timestamp": "2025-02-06T03:39:50.463608725"
+        "timestamp": "2025-02-28T10:39:47.199132"
     }
 }


### PR DESCRIPTION
To use the QC files at the end of a pipeline, we need to collect them through all of the subworkflows so that they are moved up to the pipeline level. I added an empty channel at the beginning of each subworkflows, and mix the qc files in them for modules that already have a QC.