### PR TITLE
Fix meta for proper build of documentation site with versioning

### DIFF
--- a/modules/nf-neuro/preproc/normalize/meta.yml
+++ b/modules/nf-neuro/preproc/normalize/meta.yml
@@ -35,12 +35,12 @@ input:
   - bval:
       type: file
       description: Text file containing b-values
-      pattern: "*.{.bval}"
+      pattern: "*.bval"
 
   - bvec:
       type: file
       description: Text file containing b-vectors
-      pattern: "*.{.bvec}"
+      pattern: "*.bvec"
 
 output:
   - meta:

--- a/modules/nf-neuro/registration/synthregistration/meta.yml
+++ b/modules/nf-neuro/registration/synthregistration/meta.yml
@@ -40,7 +40,7 @@ output:
   - warped_image:
       type: file
       description: Warped image
-      pattern: "*.{nii,.nii.gz}"
+      pattern: "*.{nii,nii.gz}"
 
   - transfo_image:
       type: list

--- a/subworkflows/nf-neuro/registration/meta.yml
+++ b/subworkflows/nf-neuro/registration/meta.yml
@@ -80,7 +80,7 @@ output:
         Channel containing the image transformation files. This channel contains the necessary transformation
         files (warp and affine) to perform the anatomical -> dwi space registration. Those files could be
         used in the future to bring anatomical labels into DWI space for connectomics.
-        Structure: [ val(meta), [ path(warp), <path(affine)> ] ]
+        Structure: [ val(meta), [ path(warp), path(affine) ] ]
       pattern: "*.{nii,nii.gz,mat}"
   - transfo_trk:
       type: file
@@ -88,7 +88,7 @@ output:
         Channel containing the tractogram transformation files. This channel contains the necessary transformation
         files (inverseAffine, inverseWarp) to perform the dwi -> anatomical space registration. Those files could
         be used to register tractograms or bundle in the subject's anatomical space.
-        Structure: [ val(meta), [ <path(inverseAffine)>, path(inverseWarp) ]
+        Structure: [ val(meta), [ path(inverseAffine), path(inverseWarp) ]
       pattern: "*.{nii,nii.gz,mat}"
   - ref_warped:
       type: file

--- a/subworkflows/nf-neuro/tractoflow/meta.yml
+++ b/subworkflows/nf-neuro/tractoflow/meta.yml
@@ -168,12 +168,12 @@ output:
       type: file
       description: |
         Transformation matrix from the anatomical space to the diffusion space.
-        Structure: [ val(meta), [<path(warp)>, path(affine)] ]
+        Structure: [ val(meta), [path(warp), path(affine)] ]
   - diffusion_to_anatomical:
       type: file
       description: |
         Transformation matrix from the diffusion space to the anatomical space.
-        Structure: [ val(meta), [path(affine), <path(warp)>] ]
+        Structure: [ val(meta), [path(affine), path(warp)] ]
   - t1_native:
       type: file
       description: |


### PR DESCRIPTION
Some characters in a couple of `meta.yml` files were making the build of the documentation website fail. Those fixes solve the issue.

Linked to https://github.com/scilus/nf-neuro-documentation/pull/24