### PR TITLE
Hotfix - devcontainer

### DIFF
--- a/.devcontainer/devops/Dockerfile
+++ b/.devcontainer/devops/Dockerfile
@@ -27,3 +27,6 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - &&\
 
 RUN mkdir /generated && chown yeoman:yeoman /generated
 WORKDIR /generated
+
+RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+    && echo "$SNIPPET" >> "/root/.bashrc"

--- a/.devcontainer/devops/devcontainer.json
+++ b/.devcontainer/devops/devcontainer.json
@@ -41,16 +41,16 @@
             "type": "volume"
         },
         {
-            "target": "/tmp",
-            "type": "volume"
-        },
-        {
-            "source": "nf-neuro-profile",
-            "target": "/root",
+            "source": "nf-neuro-bash-history",
+            "target": "/commandhistory",
             "type": "volume"
         },
         {
             "target": "/root/.vscode-server",
+            "type": "volume"
+        },
+        {
+            "target": "/tmp",
             "type": "volume"
         }
     ],

--- a/.devcontainer/devops/devcontainer.json
+++ b/.devcontainer/devops/devcontainer.json
@@ -19,7 +19,10 @@
     "features": {
         "ghcr.io/devcontainers/features/git:1": {},
         "ghcr.io/devcontainers/features/github-cli:1": {},
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+            "dockerDashComposeVersion": "none",
+            "installDockerComposeSwitch": false
+        },
         "ghcr.io/devcontainers-contrib/features/apt-get-packages:1": {},
         "ghcr.io/robsyme/features/nextflow:1": {},
         "ghcr.io/devcontainers-contrib/features/curl-apt-get:1": {},

--- a/.devcontainer/prototyping/devcontainer.json
+++ b/.devcontainer/prototyping/devcontainer.json
@@ -17,7 +17,10 @@
     "features": {
         "ghcr.io/devcontainers/features/git:1": {},
         "ghcr.io/devcontainers/features/github-cli:1": {},
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+            "dockerDashComposeVersion": "none",
+            "installDockerComposeSwitch": false
+        },
         "ghcr.io/devcontainers-contrib/features/apt-get-packages:1": {},
         "ghcr.io/robsyme/features/nextflow:1": {},
         "ghcr.io/devcontainers-contrib/features/curl-apt-get:1": {},


### PR DESCRIPTION
## Bug category

- [ ] Critical (some functionalities is not working at all)
- [x] Major (something is not working as expected)
- [ ] Minor (something but could be improved)
- [ ] Trivial (documentation needs correcting and other non-functional issues)

## Describe the bug

There is a memory leak in the **docker-in-docker** extension used to enable `docker run` inside of the devcontainer. It is caused by the **docker compose** sub-command, which we do not use. This PR disables it.

Also, the previous way of syncing the **bash history** between runs of the devcontainer is not working anymore. This fixes it with the method described [here](https://code.visualstudio.com/remote/advancedcontainers/persist-bash-history).

**The PR changes some volumes that get attached to the devcontainer. The old ones will have to be removed manually. It may be good to delete the complete devcontainer and volumes as well.**

## Steps to reproduce the bug

This may be only related to installation with **Docker Desktop**, and may be restricted to Linux as well, I can't say. But running any devcontainer on my laptop (8Gb) and my desktop computer (64Gb) crashes in about 1 minute, because the RAM fills up.
