### PR TITLE
Module/volume math

### DIFF
--- a/modules/nf-neuro/image/mathsingle/environment.yml
+++ b/modules/nf-neuro/image/mathsingle/environment.yml
@@ -1,0 +1,4 @@
+---
+channels: []
+dependencies: []
+name: "image_mathsingle"

--- a/modules/nf-neuro/image/mathsingle/main.nf
+++ b/modules/nf-neuro/image/mathsingle/main.nf
@@ -40,7 +40,7 @@ process IMAGE_MATHSINGLE {
     scil_volume_math.py ${task.ext.operation} $image $value \
         ${prefix}__${suffix}.nii.gz --data_type $data_type $exclude_background
 
-        cat <<-END_VERSIONS > versions.yml
+    cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         scilpy: \$(pip list | grep scilpy | tr -s ' ' | cut -d' ' -f2)
     END_VERSIONS

--- a/modules/nf-neuro/image/mathsingle/main.nf
+++ b/modules/nf-neuro/image/mathsingle/main.nf
@@ -1,0 +1,61 @@
+process IMAGE_MATH_SINGLE {
+    tag "$meta.id"
+    label 'process_single'
+
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://scil.usherbrooke.ca/containers/scilus_2.0.2.sif':
+        'scilus/scilus:2.0.2' }"
+
+    input:
+        tuple val(meta), path(image)
+
+    output:
+        tuple val(meta), path("*.nii.gz"), emit: image
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    assert task.ext.operation in ['lower_threshold', 'upper_threshold',
+    'lower_threshold_eq', 'upper_threshold_eq', 'lower_threshold_otsu',
+    'upper_threshold_otsu', 'lower_clip', 'upper_clip', 'absolute_value',
+    'round', 'ceil', 'floor', 'normalize_sum', 'normalize_max',
+    'log_10', 'log_e', 'convert', 'invert', 'dilation', 'erosion',
+    'closing', 'opening', 'blur'] : "Operation ${task.ext.operation} not \
+    supported. Supported operations are: \
+    'lower_threshold', 'upper_threshold', 'lower_threshold_eq', \
+    'upper_threshold_eq', 'lower_threshold_otsu', 'upper_threshold_otsu', \
+    'lower_clip', 'upper_clip', 'absolute_value', 'round', 'ceil', \
+    'floor', 'normalize_sum', 'normalize_max', 'log_10', 'log_e', \
+    'convert', 'invert', 'dilation', 'erosion', 'closing', 'opening', \
+    'blur'"
+
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def suffix = task.ext.suffix ?: "output"
+    def value = task.ext.value ?: ""
+    def data_type = task.ext.data_type ?: "float32"
+    def exclude_background = task.ext.exclude_background ? "--exclude_background" : ""
+    """
+    scil_volume_math.py ${task.ext.operation} $image $value \
+        ${prefix}__${suffix}.nii.gz --data_type $data_type $exclude_background
+
+        cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        scilpy: \$(pip list | grep scilpy | tr -s ' ' | cut -d' ' -f2)
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def suffix = task.ext.suffix ?: "output"
+    """
+    scil_volume_math.py -h
+    touch ${prefix}_${suffix}.nii.gz
+
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        scilpy: \$(pip list | grep scilpy | tr -s ' ' | cut -d' ' -f2)
+    END_VERSIONS
+    """
+}

--- a/modules/nf-neuro/image/mathsingle/main.nf
+++ b/modules/nf-neuro/image/mathsingle/main.nf
@@ -1,4 +1,4 @@
-process IMAGE_MATH_SINGLE {
+process IMAGE_MATHSINGLE {
     tag "$meta.id"
     label 'process_single'
 
@@ -10,7 +10,8 @@ process IMAGE_MATH_SINGLE {
         tuple val(meta), path(image)
 
     output:
-        tuple val(meta), path("*.nii.gz"), emit: image
+        tuple val(meta), path("*.nii.gz")        , emit: image
+        path "versions.yml"                      , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-neuro/image/mathsingle/meta.yml
+++ b/modules/nf-neuro/image/mathsingle/meta.yml
@@ -45,18 +45,22 @@ args:
       type: string
       description: Prefix for the output image file
       default: "${meta.id}"
+
   - suffix:
       type: string
       description: Suffix for the output image file
       default: "output"
+
   - value:
       type: string
       description: Value to use for the mathematical operation (e.g., threshold, clip, etc.)
       default: ""
+
   - data_type:
       type: string
       description: Data type for the output image (e.g., float32, int16, etc.)
       default: "float32"
+
   - exclude_background:
       type: boolean
       description: Whether to exclude the background from the operation

--- a/modules/nf-neuro/image/mathsingle/meta.yml
+++ b/modules/nf-neuro/image/mathsingle/meta.yml
@@ -1,0 +1,85 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/scilus/nf-neuro/main/modules/meta-schema.json
+name: "image_mathsingle"
+description: Simple mathematical operations on a single image (with or without a single value).
+keywords:
+  - image
+  - math
+  - scilpy
+  - operations
+  - threshold
+  - clip
+  - absolute
+  - round
+  - ceil
+  - floor
+  - normalize
+  - log
+  - convert
+  - invert
+  - dilation
+  - erosion
+  - closing
+  - opening
+  - blur
+
+tools:
+  - "scilpy":
+      description: "The Sherbrooke Connectivity Imaging Lab (SCIL) Python dMRI processing toolbox."
+      homepage: "https://github.com/scilus/scilpy.git" # This can also be a link to a documentation website.
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'test', single_end:false ]`
+
+  - image:
+      type: file
+      description: Nifti image file to do the mathematical operation on
+      pattern: "*.{nii,nii.gz}"
+
+args:
+  - prefix:
+      type: string
+      description: Prefix for the output image file
+      default: "${meta.id}"
+  - suffix:
+      type: string
+      description: Suffix for the output image file
+      default: "output"
+  - value:
+      type: string
+      description: Value to use for the mathematical operation (e.g., threshold, clip, etc.)
+      default: ""
+  - data_type:
+      type: string
+      description: Data type for the output image (e.g., float32, int16, etc.)
+      default: "float32"
+  - exclude_background:
+      type: boolean
+      description: Whether to exclude the background from the operation
+      default: false
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'test', single_end:false ]`
+
+  - image:
+      type: file
+      description: Nifti image file with the result of the mathematical operation
+      pattern: "*.{nii,nii.gz}"
+
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+
+authors:
+  - "@scilus"
+maintainers:
+  - "@scilus"

--- a/modules/nf-neuro/image/mathsingle/tests/main.nf.test
+++ b/modules/nf-neuro/image/mathsingle/tests/main.nf.test
@@ -1,0 +1,74 @@
+// TODO nf-core: Once you have added the required tests, please run the following command to build this file:
+// nf-core modules test image/mathsingle
+nextflow_process {
+
+    name "Test Process IMAGE_MATHSINGLE"
+    script "../main.nf"
+    process "IMAGE_MATHSINGLE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "image"
+    tag "image/mathsingle"
+
+    // TODO nf-core: Change the test name preferably indicating the test-data and file-format used
+    test("sarscov2 - bam") {
+
+        // TODO nf-core: If you are created a test for a chained module
+        // (the module requires running more than one process to generate the required output)
+        // add the 'setup' method here.
+        // You can find more information about how to use a 'setup' method in the docs (https://nf-co.re/docs/contributing/modules#steps-for-creating-nf-test-for-chained-modules).
+
+        when {
+            process {
+                """
+                // TODO nf-core: define inputs of the process here. Example:
+                
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+                //TODO nf-core: Add all required assertions to verify the test output.
+                // See https://nf-co.re/docs/contributing/tutorials/nf-test_assertions for more information and examples.
+            )
+        }
+
+    }
+
+    // TODO nf-core: Change the test name preferably indicating the test-data and file-format used but keep the " - stub" suffix.
+    test("sarscov2 - bam - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                // TODO nf-core: define inputs of the process here. Example:
+                
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
+                    ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+                //TODO nf-core: Add all required assertions to verify the test output.
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-neuro/image/mathsingle/tests/main.nf.test
+++ b/modules/nf-neuro/image/mathsingle/tests/main.nf.test
@@ -25,21 +25,17 @@ nextflow_process {
         }
     }
 
-    test("image - dilation") {
+    test("image - lower_threshold") {
+        config "./nextflow.config"
         when {
             process {
                 """
-                    ch_split_test_data = LOAD_DATA.out.test_data_directory
-                    .branch{
-                        image: it.simpleName == "antsbet.zip"
-                    }
-
-                    input[0] = ch_split_test_data.map{
-                        test_data_directory -> [
-                            [ id:'test', single_end:false ],
-                            file("\${test_data_directory}/t1_brain_probability_map.nii.gz")
-                        ]
-                    }
+                input[0] = LOAD_DATA.out.test_data_directory.map{
+                    test_data_directory -> [
+                        [ id:'test', single_end:false ],
+                        file("\${test_data_directory}/t1_brain_probability_map.nii.gz")
+                    ]
+                }
                 """
             }
         }
@@ -58,17 +54,12 @@ nextflow_process {
         when {
             process {
                 """
-                    ch_split_test_data = LOAD_DATA.out.test_data_directory
-                    .branch{
-                        image: it.simpleName == "antsbet"
-                    }
-
-                    input[0] = ch_split_test_data.map{
-                        test_data_directory -> [
-                            [ id:'test', single_end:false ],
-                            file("\${test_data_directory}/t1_brain_probability_map.nii.gz")
-                        ]
-                    }
+                input[0] = LOAD_DATA.out.test_data_directory.map{
+                    test_data_directory -> [
+                        [ id:'test', single_end:false ],
+                        file("\${test_data_directory}/t1_brain_probability_map.nii.gz")
+                    ]
+                }
                 """
             }
         }

--- a/modules/nf-neuro/image/mathsingle/tests/main.nf.test
+++ b/modules/nf-neuro/image/mathsingle/tests/main.nf.test
@@ -1,74 +1,72 @@
-// TODO nf-core: Once you have added the required tests, please run the following command to build this file:
-// nf-core modules test image/mathsingle
 nextflow_process {
 
     name "Test Process IMAGE_MATHSINGLE"
     script "../main.nf"
     process "IMAGE_MATHSINGLE"
+    config "./nextflow.config"
 
     tag "modules"
     tag "modules_nfcore"
     tag "image"
     tag "image/mathsingle"
+    tag "subworkflows"
+    tag "subworkflows/load_test_data"
 
-    // TODO nf-core: Change the test name preferably indicating the test-data and file-format used
-    test("sarscov2 - bam") {
-
-        // TODO nf-core: If you are created a test for a chained module
-        // (the module requires running more than one process to generate the required output)
-        // add the 'setup' method here.
-        // You can find more information about how to use a 'setup' method in the docs (https://nf-co.re/docs/contributing/modules#steps-for-creating-nf-test-for-chained-modules).
-
-        when {
+    setup {
+        run("LOAD_TEST_DATA", alias: "LOAD_DATA") {
+            script "../../../../../subworkflows/nf-neuro/load_test_data/main.nf"
             process {
                 """
-                // TODO nf-core: define inputs of the process here. Example:
-                
-                input[0] = [
-                    [ id:'test', single_end:false ], // meta map
-                    file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
-                ]
+                input[0] = Channel.from( [ "antsbet.zip" ] )
+                input[1] = "test.load-test-data"
                 """
             }
         }
-
-        then {
-            assertAll(
-                { assert process.success },
-                { assert snapshot(process.out).match() }
-                //TODO nf-core: Add all required assertions to verify the test output.
-                // See https://nf-co.re/docs/contributing/tutorials/nf-test_assertions for more information and examples.
-            )
-        }
-
     }
 
-    // TODO nf-core: Change the test name preferably indicating the test-data and file-format used but keep the " - stub" suffix.
-    test("sarscov2 - bam - stub") {
-
-        options "-stub"
-
+    test("example - simple") {
+        config "./nextflow.config"
         when {
             process {
                 """
-                // TODO nf-core: define inputs of the process here. Example:
-                
-                input[0] = [
-                    [ id:'test', single_end:false ], // meta map
-                    file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
+                input[0] = LOAD_DATA.out.test_data_directory.map{
+                    test_data_directory -> [
+                        [ id:'test', single_end:false ], // meta map    -> your meta
+                        file("\${test_data_directory}/t1_brain_probability_map.nii.gz") // -> your image file.
                     ]
+                }
                 """
             }
         }
-
         then {
             assertAll(
                 { assert process.success },
                 { assert snapshot(process.out).match() }
-                //TODO nf-core: Add all required assertions to verify the test output.
             )
         }
-
     }
 
+
+    test("example - stub") {
+        options "-stub"y
+        config "./nextflow.config"
+        when {
+            process {
+                """
+                input[0] = LOAD_DATA.out.test_data_directory.map{
+                    test_data_directory -> [
+                        [ id:'test', single_end:false ], // meta map    -> your meta
+                        file("\${test_data_directory}/image.nii.gz") // -> your image file.
+                    ]
+                }
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
 }

--- a/modules/nf-neuro/image/mathsingle/tests/main.nf.test
+++ b/modules/nf-neuro/image/mathsingle/tests/main.nf.test
@@ -67,7 +67,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(process.out.versions).match() }
             )
         }
     }

--- a/modules/nf-neuro/image/mathsingle/tests/main.nf.test
+++ b/modules/nf-neuro/image/mathsingle/tests/main.nf.test
@@ -27,6 +27,7 @@ nextflow_process {
 
     test("image - lower_threshold") {
         config "./nextflow.config"
+
         when {
             process {
                 """
@@ -47,10 +48,10 @@ nextflow_process {
         }
     }
 
-
     test("image - stub") {
-        options "-stub"
+        options "-stub-run"
         config "./nextflow.config"
+
         when {
             process {
                 """
@@ -71,3 +72,5 @@ nextflow_process {
         }
     }
 }
+
+

--- a/modules/nf-neuro/image/mathsingle/tests/main.nf.test
+++ b/modules/nf-neuro/image/mathsingle/tests/main.nf.test
@@ -31,12 +31,12 @@ nextflow_process {
                 """
                     ch_split_test_data = LOAD_DATA.out.test_data_directory
                     .branch{
-                        image: it.simpleName == "antsbet"
+                        image: it.simpleName == "antsbet.zip"
                     }
 
                     input[0] = ch_split_test_data.map{
                         test_data_directory -> [
-                            [ id:'test', ],
+                            [ id:'test', single_end:false ],
                             file("\${test_data_directory}/t1_brain_probability_map.nii.gz")
                         ]
                     }
@@ -52,8 +52,8 @@ nextflow_process {
     }
 
 
-    test("example - stub") {
-        options "-stub"y
+    test("image - stub") {
+        options "-stub"
         config "./nextflow.config"
         when {
             process {
@@ -65,7 +65,7 @@ nextflow_process {
 
                     input[0] = ch_split_test_data.map{
                         test_data_directory -> [
-                            [ id:'test', ],
+                            [ id:'test', single_end:false ],
                             file("\${test_data_directory}/t1_brain_probability_map.nii.gz")
                         ]
                     }

--- a/modules/nf-neuro/image/mathsingle/tests/main.nf.test
+++ b/modules/nf-neuro/image/mathsingle/tests/main.nf.test
@@ -9,6 +9,7 @@ nextflow_process {
     tag "modules_nfcore"
     tag "image"
     tag "image/mathsingle"
+
     tag "subworkflows"
     tag "subworkflows/load_test_data"
 
@@ -24,17 +25,21 @@ nextflow_process {
         }
     }
 
-    test("example - simple") {
-        config "./nextflow.config"
+    test("image - dilation") {
         when {
             process {
                 """
-                input[0] = LOAD_DATA.out.test_data_directory.map{
-                    test_data_directory -> [
-                        [ id:'test', single_end:false ], // meta map    -> your meta
-                        file("\${test_data_directory}/t1_brain_probability_map.nii.gz") // -> your image file.
-                    ]
-                }
+                    ch_split_test_data = LOAD_DATA.out.test_data_directory
+                    .branch{
+                        image: it.simpleName == "antsbet"
+                    }
+
+                    input[0] = ch_split_test_data.map{
+                        test_data_directory -> [
+                            [ id:'test', ],
+                            file("\${test_data_directory}/t1_brain_probability_map.nii.gz")
+                        ]
+                    }
                 """
             }
         }
@@ -53,12 +58,17 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = LOAD_DATA.out.test_data_directory.map{
-                    test_data_directory -> [
-                        [ id:'test', single_end:false ], // meta map    -> your meta
-                        file("\${test_data_directory}/image.nii.gz") // -> your image file.
-                    ]
-                }
+                    ch_split_test_data = LOAD_DATA.out.test_data_directory
+                    .branch{
+                        image: it.simpleName == "antsbet"
+                    }
+
+                    input[0] = ch_split_test_data.map{
+                        test_data_directory -> [
+                            [ id:'test', ],
+                            file("\${test_data_directory}/t1_brain_probability_map.nii.gz")
+                        ]
+                    }
                 """
             }
         }

--- a/modules/nf-neuro/image/mathsingle/tests/main.nf.test.snap
+++ b/modules/nf-neuro/image/mathsingle/tests/main.nf.test.snap
@@ -1,0 +1,49 @@
+{
+    "image - stub": {
+        "content": [
+            [
+                "versions.yml:md5,8f977a45a021f6093638e92e1ba4efc1"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "25.04.2"
+        },
+        "timestamp": "2025-05-29T12:12:28.292893548"
+    },
+    "image - lower_threshold": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test__thr.nii.gz:md5,cb81e82131721a035c6c3a897113dc77"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,8f977a45a021f6093638e92e1ba4efc1"
+                ],
+                "image": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test__thr.nii.gz:md5,cb81e82131721a035c6c3a897113dc77"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,8f977a45a021f6093638e92e1ba4efc1"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "25.04.2"
+        },
+        "timestamp": "2025-05-29T12:12:24.10037522"
+    }
+}

--- a/modules/nf-neuro/image/mathsingle/tests/nextflow.config
+++ b/modules/nf-neuro/image/mathsingle/tests/nextflow.config
@@ -1,6 +1,6 @@
 
     process {
-        withName: "MATH_SINGLE" {
+        withName: "IMAGE_MATHSINGLE" {
                 ext.operation = "dilation"
                 ext.value = 2
                 ext.suffix = "dilated"

--- a/modules/nf-neuro/image/mathsingle/tests/nextflow.config
+++ b/modules/nf-neuro/image/mathsingle/tests/nextflow.config
@@ -1,0 +1,9 @@
+
+    process {
+        withName: "MATH_SINGLE" {
+                ext.operation = "dilation"
+                ext.value = 2
+                ext.suffix = "dilated"
+                ext.data_type = "uint8"
+            }
+    }

--- a/modules/nf-neuro/image/mathsingle/tests/nextflow.config
+++ b/modules/nf-neuro/image/mathsingle/tests/nextflow.config
@@ -6,4 +6,6 @@
                 ext.suffix = "dilated"
                 ext.data_type = "uint8"
             }
+        memory = '1G'
+        cpus = 1
     }

--- a/modules/nf-neuro/image/mathsingle/tests/nextflow.config
+++ b/modules/nf-neuro/image/mathsingle/tests/nextflow.config
@@ -2,7 +2,7 @@
     process {
         withName: "IMAGE_MATHSINGLE" {
                 ext.operation = "lower_threshold"
-                ext.value = -1
+                ext.value = 0.001
                 ext.suffix = "thr"
                 ext.data_type = "uint8"
             }

--- a/modules/nf-neuro/image/mathsingle/tests/nextflow.config
+++ b/modules/nf-neuro/image/mathsingle/tests/nextflow.config
@@ -1,9 +1,9 @@
 
     process {
         withName: "IMAGE_MATHSINGLE" {
-                ext.operation = "dilation"
-                ext.value = 2
-                ext.suffix = "dilated"
+                ext.operation = "lower_threshold"
+                ext.value = -1
+                ext.suffix = "thr"
                 ext.data_type = "uint8"
             }
         memory = '1G'

--- a/modules/nf-neuro/image/mathsingle/tests/tags.yml
+++ b/modules/nf-neuro/image/mathsingle/tests/tags.yml
@@ -1,0 +1,2 @@
+image/mathsingle:
+  - "modules/nf-neuro/image/mathsingle/**"

--- a/modules/nf-neuro/stats/metricsinroi/tests/main.nf.test
+++ b/modules/nf-neuro/stats/metricsinroi/tests/main.nf.test
@@ -68,10 +68,10 @@ nextflow_process {
                 input[0] = ch_split_test_data.plot.map{
                     test_data_directory -> [
                         [ id:'test', single_end:false ], // meta map
-                        [ file("\${test_data_directory}/fa.nii.gz"),
-                          file("\${test_data_directory}/ad.nii.gz")],
-                        file("\${test_data_directory}/atlas_brainnetome.nii.gz"),
-                        file("\${test_data_directory}/atlas_brainnetome.json")
+                        [   file("\${test_data_directory}/fa.nii.gz"),
+                            file("\${test_data_directory}/ad.nii.gz")],
+                            file("\${test_data_directory}/atlas_brainnetome.nii.gz"),
+                            file("\${test_data_directory}/atlas_brainnetome.json")
                     ]
                 }
                 """
@@ -97,11 +97,11 @@ nextflow_process {
                     }
                 input[0] = ch_split_test_data.plot.map{
                     test_data_directory -> [
-                        [ id:'test', single_end:false ], // meta map
-                        [ file("\${test_data_directory}/fa.nii.gz"),
-                          file("\${test_data_directory}/ad.nii.gz")],
-                        file("\${test_data_directory}/atlas_brainnetome.nii.gz"),
-                        file("\${test_data_directory}/atlas_brainnetome.json")
+                        [   id:'test', single_end:false ], // meta map
+                        [   file("\${test_data_directory}/fa.nii.gz"),
+                            file("\${test_data_directory}/ad.nii.gz")],
+                            file("\${test_data_directory}/atlas_brainnetome.nii.gz"),
+                            file("\${test_data_directory}/atlas_brainnetome.json")
                     ]
                 }
                 """


### PR DESCRIPTION
## Describe your changes
Simple process to do image operation on nifti using single input or single input and a value (convert, threshold, dilation, blur, etc.). This is useful to threshold customize tracking for example (dilate your WM, threshold your FA, binarize a probability map to a custom percentage, etc).

**Another PR will be about operation with N input (addition, average, union, concatenate, etc).**

## Checklist before requesting a review

- Create the tool:
  - [x] Edit `./modules/nf-neuro/<category>/<tool>/main.nf`
  - [x] Edit `./modules/nf-neuro/<category>/<tool>/meta.yml`
  - [x] Edit `./modules/nf-neuro/<category>/<tool>/environment.yml`
- Generate the tests:
  - [x] Edit `./modules/nf-neuro/<category>/<tool>/tests/main.nf.test`
  - [x] Run the tests to generate the `main.nf.test.snap` snapshots
- Ensure the syntax is correct :
  - [x] Run `prettier` and `editorconfig-checker` to fix common syntax issues
  - [x] Run `nf-core modules lint` and fix all errors
  - [x] Ensure your variables have good, clear names
