### PR TITLE
[HOTFIX] Update deprecated devcontainer features

### DIFF
--- a/.devcontainer/devops/devcontainer.json
+++ b/.devcontainer/devops/devcontainer.json
@@ -23,11 +23,11 @@
             "dockerDashComposeVersion": "none",
             "installDockerComposeSwitch": false
         },
-        "ghcr.io/devcontainers-contrib/features/apt-get-packages:1": {},
+        "ghcr.io/devcontainers-extra/features/apt-get-packages:1": {},
         "ghcr.io/robsyme/features/nextflow:1": {},
-        "ghcr.io/devcontainers-contrib/features/curl-apt-get:1": {},
-        "ghcr.io/devcontainers-contrib/features/tmux-apt-get:1": {},
-        "ghcr.io/devcontainers-contrib/features/wget-apt-get:1": {}
+        "ghcr.io/devcontainers-extra/features/curl-apt-get:1": {},
+        "ghcr.io/devcontainers-extra/features/tmux-apt-get:1": {},
+        "ghcr.io/devcontainers-extra/features/wget-apt-get:1": {}
     },
     "mounts": [
         {

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -76,4 +76,5 @@ options:
     - WIP
     - Work in progress
     - Hotfix
+    - HOTFIX
   number_of_reviewers: 2


### PR DESCRIPTION
## Bug category

- [ ] Critical (some functionalities is not working at all)
- [x] Major (something is not working as expected)
- [ ] Minor (something but could be improved)
- [ ] Trivial (documentation needs correcting and other non-functional issues)

## Describe the bug

The devcontainer build fails because some features have changed **URL** (switched from `contrib` to `extra`)
