### PR TITLE
FIX: Add resampled b0 as ref for mask resampling in `preproc_dwi`

### DIFF
--- a/modules/nf-neuro/image/resample/main.nf
+++ b/modules/nf-neuro/image/resample/main.nf
@@ -3,9 +3,7 @@ process IMAGE_RESAMPLE {
     label 'process_single'
     label 'process_high_memory'
 
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://scil.usherbrooke.ca/containers/scilus_2.0.2.sif':
-        'scilus/scilus:2.0.2' }"
+    container "scilus/scilpy:2.2.0_cpu"
 
     input:
     tuple val(meta), path(image), path(ref) /* optional, input = [] */
@@ -33,28 +31,27 @@ process IMAGE_RESAMPLE {
     export OMP_NUM_THREADS=1
     export OPENBLAS_NUM_THREADS=1
 
-    scil_volume_resample.py $image ${prefix}_${suffix}.nii.gz \
+    scil_volume_resample $image ${prefix}_${suffix}.nii.gz \
         $voxel_size $volume_size $reference $iso_min \
         $f $enforce_dimensions $interp
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        scilpy: \$(pip list | grep scilpy | tr -s ' ' | cut -d' ' -f2)
+        scilpy: \$(uv pip -q list | grep scilpy | tr -s ' ' | cut -d' ' -f2)
     END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def suffix = task.ext.first_suffix ? "${task.ext.first_suffix}_resampled" : "resampled"
     """
-    scil_volume_resample.py -h
+    scil_volume_resample -h
 
     touch ${prefix}_${suffix}.nii.gz
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        scilpy: \$(pip list | grep scilpy | tr -s ' ' | cut -d' ' -f2)
+        scilpy: \$(uv pip -q list | grep scilpy | tr -s ' ' | cut -d' ' -f2)
     END_VERSIONS
     """
 }

--- a/modules/nf-neuro/image/resample/tests/main.nf.test.snap
+++ b/modules/nf-neuro/image/resample/tests/main.nf.test.snap
@@ -2,14 +2,14 @@
     "image - resample - stub-run": {
         "content": [
             [
-                "versions.yml:md5,06181e25531a3ebdefdfd2e641a3d645"
+                "versions.yml:md5,90172e8692b979be08f9e7d775893ad8"
             ]
         ],
         "meta": {
             "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2024-11-28T18:48:51.114688771"
+        "timestamp": "2025-09-16T20:46:08.095689338"
     },
     "image - resample - isomin": {
         "content": [
@@ -24,7 +24,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,06181e25531a3ebdefdfd2e641a3d645"
+                    "versions.yml:md5,90172e8692b979be08f9e7d775893ad8"
                 ],
                 "image": [
                     [
@@ -36,15 +36,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,06181e25531a3ebdefdfd2e641a3d645"
+                    "versions.yml:md5,90172e8692b979be08f9e7d775893ad8"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2024-10-24T15:30:19.061192"
+        "timestamp": "2025-09-16T20:42:42.725857841"
     },
     "image - resample - nn": {
         "content": [
@@ -59,7 +59,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,06181e25531a3ebdefdfd2e641a3d645"
+                    "versions.yml:md5,90172e8692b979be08f9e7d775893ad8"
                 ],
                 "image": [
                     [
@@ -71,15 +71,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,06181e25531a3ebdefdfd2e641a3d645"
+                    "versions.yml:md5,90172e8692b979be08f9e7d775893ad8"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2024-10-24T15:30:42.725713"
+        "timestamp": "2025-09-16T20:45:38.322035422"
     },
     "image - resample - volsize": {
         "content": [
@@ -94,7 +94,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,06181e25531a3ebdefdfd2e641a3d645"
+                    "versions.yml:md5,90172e8692b979be08f9e7d775893ad8"
                 ],
                 "image": [
                     [
@@ -106,15 +106,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,06181e25531a3ebdefdfd2e641a3d645"
+                    "versions.yml:md5,90172e8692b979be08f9e7d775893ad8"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2024-10-24T15:30:07.1626"
+        "timestamp": "2025-09-16T20:42:07.088799546"
     },
     "image - resample - voxsize": {
         "content": [
@@ -129,7 +129,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,06181e25531a3ebdefdfd2e641a3d645"
+                    "versions.yml:md5,90172e8692b979be08f9e7d775893ad8"
                 ],
                 "image": [
                     [
@@ -141,15 +141,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,06181e25531a3ebdefdfd2e641a3d645"
+                    "versions.yml:md5,90172e8692b979be08f9e7d775893ad8"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2024-11-28T18:31:36.84484801"
+        "timestamp": "2025-09-16T20:41:36.179272588"
     },
     "image - resample - ref": {
         "content": [
@@ -164,7 +164,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,06181e25531a3ebdefdfd2e641a3d645"
+                    "versions.yml:md5,90172e8692b979be08f9e7d775893ad8"
                 ],
                 "image": [
                     [
@@ -176,14 +176,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,06181e25531a3ebdefdfd2e641a3d645"
+                    "versions.yml:md5,90172e8692b979be08f9e7d775893ad8"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2024-10-24T15:30:31.018615"
+        "timestamp": "2025-09-16T20:45:08.941753006"
     }
 }

--- a/subworkflows/nf-neuro/preproc_dwi/main.nf
+++ b/subworkflows/nf-neuro/preproc_dwi/main.nf
@@ -166,7 +166,7 @@ workflow PREPROC_DWI {
 
         // ** Resample mask ** //
         ch_resample_mask = BETCROP_FSLBETCROP.out.mask
-            .map{ it + [[]] }
+            .join(EXTRACTB0_RESAMPLE.out.b0)
 
         RESAMPLE_MASK ( ch_resample_mask )
         ch_versions = ch_versions.mix(RESAMPLE_MASK.out.versions.first())

--- a/subworkflows/nf-neuro/preproc_dwi/tests/main.nf.test.snap
+++ b/subworkflows/nf-neuro/preproc_dwi/tests/main.nf.test.snap
@@ -90,24 +90,24 @@
                 "versions": [
                     "versions.yml:md5,034b6d262d1e0e45c673d3ac1756e22f",
                     "versions.yml:md5,10ec368dc91791041043fddf6ea3d5c9",
-                    "versions.yml:md5,218c08543fae3d1e7dd9b1527aa67a21",
                     "versions.yml:md5,2a21b128aa5c69a8532e114406dae21d",
-                    "versions.yml:md5,4f645295735c7f79182fd589063e11a5",
+                    "versions.yml:md5,341db3ceefafcc7f6ed94daebf9b4b9c",
                     "versions.yml:md5,571265e710ca29198e69be22c0f970d5",
                     "versions.yml:md5,662ea558da42564a0f6140473132bcb4",
                     "versions.yml:md5,7ddf2e98f59b19c9b933670550f26ad7",
                     "versions.yml:md5,96b217735e8b8f2f6a2d0f43f94d51e5",
                     "versions.yml:md5,cad56766a7aba84e153c3be70f8c48f2",
                     "versions.yml:md5,ea5858879452a59bb355228ae7f38111",
+                    "versions.yml:md5,ed801d1dbdfc6c31e103bcfd124eeb03",
                     "versions.yml:md5,f041502e22449973d84ac1c618e8ebf9"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "25.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.2"
         },
-        "timestamp": "2025-07-04T05:18:38.911846578"
+        "timestamp": "2025-08-25T15:29:04.574408"
     },
     "preproc_dwi - AP DWI | PA sbref": {
         "content": [
@@ -200,8 +200,8 @@
                 "versions": [
                     "versions.yml:md5,034b6d262d1e0e45c673d3ac1756e22f",
                     "versions.yml:md5,10ec368dc91791041043fddf6ea3d5c9",
-                    "versions.yml:md5,218c08543fae3d1e7dd9b1527aa67a21",
                     "versions.yml:md5,2a21b128aa5c69a8532e114406dae21d",
+                    "versions.yml:md5,341db3ceefafcc7f6ed94daebf9b4b9c",
                     "versions.yml:md5,571265e710ca29198e69be22c0f970d5",
                     "versions.yml:md5,7ddf2e98f59b19c9b933670550f26ad7",
                     "versions.yml:md5,96b217735e8b8f2f6a2d0f43f94d51e5",
@@ -212,10 +212,10 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "25.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.2"
         },
-        "timestamp": "2025-07-04T05:14:06.490352045"
+        "timestamp": "2025-08-25T15:25:55.889337"
     },
     "preproc_dwi - AP DWI | PA DWI": {
         "content": [
@@ -308,23 +308,23 @@
                 "versions": [
                     "versions.yml:md5,034b6d262d1e0e45c673d3ac1756e22f",
                     "versions.yml:md5,10ec368dc91791041043fddf6ea3d5c9",
-                    "versions.yml:md5,218c08543fae3d1e7dd9b1527aa67a21",
                     "versions.yml:md5,2a21b128aa5c69a8532e114406dae21d",
-                    "versions.yml:md5,4f645295735c7f79182fd589063e11a5",
+                    "versions.yml:md5,341db3ceefafcc7f6ed94daebf9b4b9c",
                     "versions.yml:md5,571265e710ca29198e69be22c0f970d5",
                     "versions.yml:md5,662ea558da42564a0f6140473132bcb4",
                     "versions.yml:md5,7ddf2e98f59b19c9b933670550f26ad7",
                     "versions.yml:md5,96b217735e8b8f2f6a2d0f43f94d51e5",
                     "versions.yml:md5,cad56766a7aba84e153c3be70f8c48f2",
                     "versions.yml:md5,ea5858879452a59bb355228ae7f38111",
+                    "versions.yml:md5,ed801d1dbdfc6c31e103bcfd124eeb03",
                     "versions.yml:md5,f041502e22449973d84ac1c618e8ebf9"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "25.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.2"
         },
-        "timestamp": "2025-07-04T05:16:22.256421639"
+        "timestamp": "2025-08-25T15:27:49.411598"
     }
 }

--- a/subworkflows/nf-neuro/preproc_dwi/tests/main.nf.test.snap
+++ b/subworkflows/nf-neuro/preproc_dwi/tests/main.nf.test.snap
@@ -94,20 +94,20 @@
                     "versions.yml:md5,341db3ceefafcc7f6ed94daebf9b4b9c",
                     "versions.yml:md5,571265e710ca29198e69be22c0f970d5",
                     "versions.yml:md5,662ea558da42564a0f6140473132bcb4",
-                    "versions.yml:md5,7ddf2e98f59b19c9b933670550f26ad7",
                     "versions.yml:md5,96b217735e8b8f2f6a2d0f43f94d51e5",
+                    "versions.yml:md5,a585ae0f02b31e59f3f641836f5cb608",
+                    "versions.yml:md5,c7da6834a9868efe7d6878ae023a6782",
                     "versions.yml:md5,cad56766a7aba84e153c3be70f8c48f2",
-                    "versions.yml:md5,ea5858879452a59bb355228ae7f38111",
                     "versions.yml:md5,ed801d1dbdfc6c31e103bcfd124eeb03",
                     "versions.yml:md5,f041502e22449973d84ac1c618e8ebf9"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.2"
+            "nf-test": "0.9.0",
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-08-25T15:29:04.574408"
+        "timestamp": "2025-09-16T22:11:24.590446506"
     },
     "preproc_dwi - AP DWI | PA sbref": {
         "content": [
@@ -203,19 +203,19 @@
                     "versions.yml:md5,2a21b128aa5c69a8532e114406dae21d",
                     "versions.yml:md5,341db3ceefafcc7f6ed94daebf9b4b9c",
                     "versions.yml:md5,571265e710ca29198e69be22c0f970d5",
-                    "versions.yml:md5,7ddf2e98f59b19c9b933670550f26ad7",
                     "versions.yml:md5,96b217735e8b8f2f6a2d0f43f94d51e5",
+                    "versions.yml:md5,a585ae0f02b31e59f3f641836f5cb608",
+                    "versions.yml:md5,c7da6834a9868efe7d6878ae023a6782",
                     "versions.yml:md5,cad56766a7aba84e153c3be70f8c48f2",
-                    "versions.yml:md5,ea5858879452a59bb355228ae7f38111",
                     "versions.yml:md5,f041502e22449973d84ac1c618e8ebf9"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.2"
+            "nf-test": "0.9.0",
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-08-25T15:25:55.889337"
+        "timestamp": "2025-09-16T22:08:31.630302551"
     },
     "preproc_dwi - AP DWI | PA DWI": {
         "content": [
@@ -312,19 +312,19 @@
                     "versions.yml:md5,341db3ceefafcc7f6ed94daebf9b4b9c",
                     "versions.yml:md5,571265e710ca29198e69be22c0f970d5",
                     "versions.yml:md5,662ea558da42564a0f6140473132bcb4",
-                    "versions.yml:md5,7ddf2e98f59b19c9b933670550f26ad7",
                     "versions.yml:md5,96b217735e8b8f2f6a2d0f43f94d51e5",
+                    "versions.yml:md5,a585ae0f02b31e59f3f641836f5cb608",
+                    "versions.yml:md5,c7da6834a9868efe7d6878ae023a6782",
                     "versions.yml:md5,cad56766a7aba84e153c3be70f8c48f2",
-                    "versions.yml:md5,ea5858879452a59bb355228ae7f38111",
                     "versions.yml:md5,ed801d1dbdfc6c31e103bcfd124eeb03",
                     "versions.yml:md5,f041502e22449973d84ac1c618e8ebf9"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.2"
+            "nf-test": "0.9.0",
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-08-25T15:27:49.411598"
+        "timestamp": "2025-09-16T22:09:59.224327674"
     }
 }

--- a/subworkflows/nf-neuro/preproc_t1/tests/main.nf.test.snap
+++ b/subworkflows/nf-neuro/preproc_t1/tests/main.nf.test.snap
@@ -27,7 +27,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,bdd934b4b8456060c36d6d97e4f30740",
+                    "versions.yml:md5,b539f60cb48d0e92cd7dcf2f403d3ea9",
                     "versions.yml:md5,bf4dd58c38dd4863ebfb9e78a94c3a20",
                     "versions.yml:md5,ea32c30f5320f720b2f5dc32ac2535ea"
                 ]
@@ -35,9 +35,9 @@
         ],
         "meta": {
             "nf-test": "0.9.0",
-            "nextflow": "24.04.5"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-06-09T05:10:44.027554806"
+        "timestamp": "2025-09-16T22:13:27.309592382"
     },
     "preproc_t1_synthbet": {
         "content": [
@@ -109,7 +109,7 @@
                 "versions": [
                     "versions.yml:md5,318cabe934be45528a25f52083d9c90d",
                     "versions.yml:md5,7aad91b5043d2dc8e8fc69ffbbe6f657",
-                    "versions.yml:md5,bdd934b4b8456060c36d6d97e4f30740",
+                    "versions.yml:md5,b539f60cb48d0e92cd7dcf2f403d3ea9",
                     "versions.yml:md5,be3dbb0ac2589ad263d583018f339102",
                     "versions.yml:md5,bf4dd58c38dd4863ebfb9e78a94c3a20",
                     "versions.yml:md5,ea32c30f5320f720b2f5dc32ac2535ea"
@@ -118,9 +118,9 @@
         ],
         "meta": {
             "nf-test": "0.9.0",
-            "nextflow": "24.04.5"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-06-27T03:05:12.610505682"
+        "timestamp": "2025-09-16T22:30:28.807360346"
     },
     "preproc_t1_skip_all": {
         "content": [
@@ -136,10 +136,10 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.5"
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-06-09T05:10:51.002651291"
+        "timestamp": "2025-09-16T10:35:13.269602"
     },
     "preproc_t1_antsbet": {
         "content": [
@@ -210,7 +210,7 @@
                 ],
                 "versions": [
                     "versions.yml:md5,7aad91b5043d2dc8e8fc69ffbbe6f657",
-                    "versions.yml:md5,bdd934b4b8456060c36d6d97e4f30740",
+                    "versions.yml:md5,b539f60cb48d0e92cd7dcf2f403d3ea9",
                     "versions.yml:md5,be3dbb0ac2589ad263d583018f339102",
                     "versions.yml:md5,bf4dd58c38dd4863ebfb9e78a94c3a20",
                     "versions.yml:md5,da278daafbe3afa8454021e2716dd205",
@@ -220,8 +220,8 @@
         ],
         "meta": {
             "nf-test": "0.9.0",
-            "nextflow": "24.04.5"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-06-27T03:04:49.134947835"
+        "timestamp": "2025-09-16T22:12:25.991289756"
     }
 }


### PR DESCRIPTION
## Bug category

- [ ] Critical (some functionalities is not working at all)
- [ ] Major (something is not working as expected)
- [x] Minor (something but could be improved)
- [ ] Trivial (documentation needs correcting and other non-functional issues)

## Describe the bug

This is not a huge bug, but in rare cases, the interpolation of the mask when resampling will give a slightly different resampling, which will make the header non-compatible in future steps of a pipeline. By setting the resampled B0 as a reference, we should be able to avoid those rare cases.

## Steps to reproduce the bug

A bit hard to do unless you have this rare case, but see https://github.com/scilus/nf-pediatric/issues/59

**[DONE] This was fix in scilpy, waiting for the next release to update the container**
