### PR TITLE
[HOTFIX] add extra step to install gawk

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -157,6 +157,9 @@ jobs:
             --debug \
             ${{ inputs.paths }}
 
+      - name: Install gawk
+        run: sudo apt-get update && sudo apt-get -y install gawk
+
       - uses: pcolby/tap-summary@0959cbe1d4422e62afc65778cdaea6716c41d936 # v1.1.1
         with:
           path: >-


### PR DESCRIPTION
## Bug category

- [ ] Critical (some functionalities is not working at all)
- [x] Major (something is not working as expected)
- [ ] Minor (something but could be improved)
- [ ] Trivial (documentation needs correcting and other non-functional issues)

## Describe the bug

There is an error in the test workflow, where `gawk` is missing for a step to complete successfully.

## Steps to reproduce the bug

Launch any PR that launches any tests.
